### PR TITLE
[FEATURE]: CI script to build and run tests on 11-15 versions of PG

### DIFF
--- a/.github/workflows/build-and-test-linux.yaml
+++ b/.github/workflows/build-and-test-linux.yaml
@@ -1,0 +1,37 @@
+name: build
+on:
+  push:
+  pull_request:
+jobs:
+  ubuntu:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - postgres: 15
+            os: ubuntu-22.04
+          - postgres: 14
+            os: ubuntu-22.04
+          - postgres: 13
+            os: ubuntu-22.04
+          - postgres: 12
+            os: ubuntu-22.04
+          - postgres: 11
+            os: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - name: Build
+        run: sudo su -c "PG_VERSION=$PG_VERSION USE_SOURCE=1 ./ci/scripts/build-linux.sh"
+        env:
+          PG_VERSION: ${{ matrix.postgres }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
+      - name: Run tests
+        run: sudo su postgres -c "PG_VERSION=$PG_VERSION ./ci/scripts/run-tests.sh"
+        env:
+          PG_VERSION: ${{ matrix.postgres }}

--- a/.github/workflows/build-and-test-linux.yaml
+++ b/.github/workflows/build-and-test-linux.yaml
@@ -1,7 +1,13 @@
 name: build
 on:
   push:
+    branches:
+      - main
+      - dev
   pull_request:
+    branches:
+      - main
+      - dev
 jobs:
   ubuntu:
     runs-on: ${{ matrix.os }}

--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+get_cmake_flags(){
+ # TODO:: remove after test
+ echo "-DUSEARCH_NO_MARCH_NATIVE=ON"
+ # if [[ $ARCH == *"arm"* ]]; then
+ #   echo "-DUSEARCH_NO_MARCH_NATIVE=ON"
+ # fi
+}
+
+export BRANCH=$BRANCH_NAME
+export POSTGRES_USER=postgres
+export DEBIAN_FRONTEND=noninteractive
+
+if [ -z "$BRANCH" ]
+then
+  BRANCH="dev"
+fi
+
+if [ -z "$PG_VERSION" ]
+then
+  export PG_VERSION=15
+fi
+
+# Set Locale
+echo "LC_ALL=en_US.UTF-8" > /etc/environment && \
+echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+echo "LANG=en_US.UTF-8" > /etc/locale.conf && \
+apt update -y && apt install locales -y && \
+locale-gen en_US.UTF-8 && \
+# Install required packages for build
+apt install lsb-core build-essential automake cmake wget git dpkg-dev wget -y && \
+# Add postgresql apt repo
+export ARCH=$(dpkg-architecture -q DEB_BUILD_ARCH) && \
+sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc |  apt-key add - &&\
+# Install postgres and dev files for C headers
+apt update && apt install postgresql-$PG_VERSION postgresql-server-dev-$PG_VERSION -y
+# Install pgvector
+apt install postgresql-$PG_VERSION-pgvector -y
+# Fix pg_config (sometimes it points to wrong version)
+rm -f /usr/bin/pg_config && ln -s /usr/lib/postgresql/$PG_VERSION/bin/pg_config /usr/bin/pg_config
+
+if [ -z ${USE_SOURCE+x} ]; then
+  # Clone from git
+  cd /tmp && git clone --recursive https://github.com/lanterndata/lanterndb.git -b $BRANCH
+else 
+  # Use already checkouted code
+  mkdir -p /tmp/lanterndb && cp -r ./* /tmp/lanterndb/
+fi
+
+cd /tmp/lanterndb && mkdir build && cd build && \
+# Run cmake
+sh -c "cmake $(get_cmake_flags) .." && \
+make install && \
+# Remove apt cache
+apt-get clean && \
+chown -R postgres:postgres /tmp/lanterndb

--- a/ci/scripts/run-tests.sh
+++ b/ci/scripts/run-tests.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+wait_for_pg(){
+ tries=0
+ until pg_isready -U postgres 2>/dev/null; do
+   if [ $tries -eq 10 ];
+   then
+     echo "Can not connect to postgres"
+     exit 1
+   fi
+   
+   sleep 1
+   tries=$((tries+1))
+ done
+}
+
+export WORKDIR=/tmp/lanterndb
+
+if [ -z "$PG_VERSION" ]
+then
+  export PG_VERSION=15
+fi
+
+export PGDATA=/etc/postgresql/$PG_VERSION/main/
+# Set port
+echo "port = 5432" >> $PGDATA/postgresql.conf
+# Run postgres database
+POSTGRES_HOST_AUTH_METHOD=trust /usr/lib/postgresql/$PG_VERSION/bin/postgres &>/dev/null &
+# Wait for start and run tests
+wait_for_pg && cd $WORKDIR/build && make test


### PR DESCRIPTION
## Description
In preparation for Github CI/CD action, added a debian installation script. The script should work on debian based postgres container. It will install lanterndb with all the required dependencies and run the tests.

## TODO
- [x] Add `postgres` installation, so the script may work on a raw debian machine
- [x] Fix version configuration with variables, so we may run the script on CI pipeline with different versions of postgres installation
- [x] Fix `cmake` command to add required flags based on architecture