### PR TITLE
Optimizations on inserts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ project(
   VERSION ${LANTERNDB_VERSION}
   LANGUAGES C CXX)
 
+if (POLICY CMP0074)
+  # us <PackageName>_ROOT variables from inside find_package calls
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 if(POLICY CMP0077)
   # Allow parent project to override options of children obtain via FetchContent
   # or add_subdirectory.
@@ -25,8 +30,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
-set(CMAKE_BUILD_TYPE "Debug")
-set(CMAKE_BUILD_TYPE "Release")
 message(STATUS "${CMAKE_COLOR_GREEN}Build type: ${CMAKE_BUILD_TYPE}${CMAKE_COLOR_RESET}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
@@ -41,6 +44,9 @@ file(GLOB SOURCES "${SOURCES_DIR}/**/*.c" "${SOURCES_DIR}/*.c")
 set(USEARCH_USE_SIMSIMD OFF)
 set(USEARCH_BUILD_LIBUSEARCH_STATIC ON)
 set(USEARCH_BUILD_LIBUSEARCH_SHARED OFF)
+# do not add asan flags to usearch debug build of the library since
+# we still have not figured out how to load those into postgres
+set(USEARCH_DEBUG_BUILD_ASAN OFF)
 # the var below can be used to skip -march=native in the usearch build
 # which causes issues when built from docker on m1 macs
 # set(USEARCH_NO_MARCH_NATIVE OFF)

--- a/src/hnsw/insert.c
+++ b/src/hnsw/insert.c
@@ -95,7 +95,15 @@ bool ldb_aminsert(Relation         index,
 
         // todo:: pass in all the additional init info for external retreiver like index size (that's all?)
         uidx = usearch_init(&opts, &error);
+        if(uidx == NULL) {
+            elog(ERROR, "unable to initialize usearch");
+        }
         assert(!error);
+        INDEX_RELATION_FOR_RETRIEVER = index;
+        HEADER_FOR_EXTERNAL_RETRIEVER = *hdr;
+        EXTRA_DIRTIED = &extra_dirtied[ 0 ];
+        EXTRA_DIRTIED_PAGE = &extra_dirtied_page[ 0 ];
+        EXTRA_DIRTIED_SIZE = 0;
         ldb_wal_retriever_area_init(BLCKSZ * 100);
         usearch_set_node_retriever(uidx, &ldb_wal_index_node_retriever, &ldb_wal_index_node_retriever_mut, &error);
 
@@ -144,12 +152,6 @@ bool ldb_aminsert(Relation         index,
 
     assert(hdr->magicNumber == LDB_WAL_MAGIC_NUMBER);
     elog(DEBUG5, "Insert: at start num vectors is %d", hdr->num_vectors);
-
-    INDEX_RELATION_FOR_RETRIEVER = index;
-    HEADER_FOR_EXTERNAL_RETRIEVER = *hdr;
-    EXTRA_DIRTIED = &extra_dirtied[ 0 ];
-    EXTRA_DIRTIED_PAGE = &extra_dirtied_page[ 0 ];
-    EXTRA_DIRTIED_SIZE = 0;
 
     current_size = hdr->num_vectors;
 

--- a/src/hnsw/insert.c
+++ b/src/hnsw/insert.c
@@ -16,6 +16,21 @@
 #include "vector.h"
 
 /*
+ * Context delete callback for insert context
+ */
+static void insert_done_cb(void *arg)
+{
+    usearch_index_t uidx = (usearch_index_t)arg;
+    usearch_error_t error = NULL;
+
+    usearch_free(uidx, &error);
+    if(error != NULL) {
+        elog(ERROR, "error freeing usearch index: %s", error);
+    }
+    ldb_wal_retriever_area_free();
+}
+
+/*
  * Insert a tuple into the index
  */
 bool ldb_aminsert(Relation         index,
@@ -31,25 +46,24 @@ bool ldb_aminsert(Relation         index,
                   ,
                   IndexInfo *indexInfo)
 {
-    MemoryContext          oldCtx;
-    MemoryContext          insertCtx;
-    Datum                  vector;
-    usearch_init_options_t opts;
-    usearch_index_t        uidx;
-    usearch_error_t        error = NULL;
-    usearch_metadata_t     meta;
-    BlockNumber            HEADER_BLOCK = 0;
-    BlockNumber            last_block;
-    Buffer                 hdr_buf;
-    Page                   hdr_page;
-    HnswIndexHeaderPage   *hdr;
-    int                    current_size;
-    GenericXLogState      *state;
-    Buffer                 extra_dirtied[ LDB_HNSW_INSERT_MAX_EXTRA_DIRTIED_BUFS ];
-    Page                   extra_dirtied_page[ LDB_HNSW_INSERT_MAX_EXTRA_DIRTIED_BUFS ];
-    int                    new_tuple_size;
-    uint32                 new_tuple_id;
-    HnswIndexTuple        *new_tuple;
+    MemoryContext        oldCtx;
+    MemoryContext        insertCtx;
+    Datum                vector;
+    usearch_index_t      uidx;
+    usearch_error_t      error = NULL;
+    usearch_metadata_t   meta;
+    BlockNumber          HEADER_BLOCK = 0;
+    BlockNumber          last_block;
+    Buffer               hdr_buf;
+    Page                 hdr_page;
+    HnswIndexHeaderPage *hdr;
+    int                  current_size;
+    GenericXLogState    *state;
+    Buffer               extra_dirtied[ LDB_HNSW_INSERT_MAX_EXTRA_DIRTIED_BUFS ];
+    Page                 extra_dirtied_page[ LDB_HNSW_INSERT_MAX_EXTRA_DIRTIED_BUFS ];
+    int                  new_tuple_size;
+    uint32               new_tuple_id;
+    HnswIndexTuple      *new_tuple;
 
     if(checkUnique != UNIQUE_CHECK_NO) {
         elog(ERROR, "unique constraints on hnsw vector indexes not supported");
@@ -61,30 +75,63 @@ bool ldb_aminsert(Relation         index,
     if(isnull[ 0 ]) {
         return false;
     }
-    {
-        // todo:
-        //  initialize usearch at indexInfo->ii_AmCache in indexInfo->ii_Context memory context
-        //  see this blog post on how to register a callback on memory context destruction to destroy usearch object
-        //  https://jnidzwetzki.github.io/2022/05/28/postgres-memory-context.html
+
+    // when there are multiple inserts in the query, avoid reinitializing some of the
+    // data structures
+    if(indexInfo->ii_AmCache == NULL) {
+        usearch_init_options_t opts;
+        MemoryContextCallback *callback;
+
+        opts.dimensions = TupleDescAttr(index->rd_att, 0)->atttypmod;
+        PopulateUsearchOpts(index, &opts);
+
+        //  read index header page to know how many pages are already inserted
+        hdr_buf = ReadBuffer(index, HEADER_BLOCK);
+        LockBuffer(hdr_buf, BUFFER_LOCK_SHARE);
+        // header page MUST be under WAL since PrepareIndexTuple will update it
+        hdr_page = BufferGetPage(hdr_buf);
+        hdr = (HnswIndexHeaderPage *)PageGetContents(hdr_page);
+        assert(hdr->magicNumber == LDB_WAL_MAGIC_NUMBER);
+
+        // todo:: pass in all the additional init info for external retreiver like index size (that's all?)
+        uidx = usearch_init(&opts, &error);
+        assert(!error);
+        ldb_wal_retriever_area_init(BLCKSZ * 100);
+        usearch_set_node_retriever(uidx, &ldb_wal_index_node_retriever, &ldb_wal_index_node_retriever_mut, &error);
+
+        assert(usearch_size(uidx, &error) == 0);
+        assert(!error);
+
+        // this reserves memory for internal structures,
+        // including for locks according to size indicated in usearch_mem
+        //  ^^ do not worry about allocaitng locks above. but that has to be eliminated down the line
+        usearch_view_mem_lazy(uidx, hdr->usearch_header, &error);
+
+        indexInfo->ii_AmCache = uidx;
+
+        callback
+            = (MemoryContextCallback *)MemoryContextAllocZero(indexInfo->ii_Context, sizeof(MemoryContextCallback));
+        callback->func = insert_done_cb;
+        callback->arg = (void *)uidx;
+        MemoryContextRegisterResetCallback(indexInfo->ii_Context, callback);
+
+        UnlockReleaseBuffer(hdr_buf);
+        // reset hdr related vars to make sure the rest of the code does not depend on them
+        // as here we read everything in read-only mode while the rest of the code will likely
+        // need exclusive access to the header page
+        hdr_buf = InvalidBuffer;
+        hdr_page = NULL;
+        hdr = NULL;
     }
+
+    uidx = (usearch_index_t)indexInfo->ii_AmCache;
+    assert(!error);
+    meta = usearch_metadata(uidx, &error);
 
     insertCtx = AllocSetContextCreate(CurrentMemoryContext, "LanternInsertContext", ALLOCSET_DEFAULT_SIZES);
     oldCtx = MemoryContextSwitchTo(insertCtx);
 
     vector = PointerGetDatum(PG_DETOAST_DATUM(values[ 0 ]));
-
-    opts.dimensions = TupleDescAttr(index->rd_att, 0)->atttypmod;
-    PopulateUsearchOpts(index, &opts);
-
-    // todo:: pass in all the additional init info for external retreiver like index size (that's all?)
-    uidx = usearch_init(&opts, &error);
-    meta = usearch_metadata(uidx, &error);
-    // USE an INSERT retriever for the above. the difference will be that the retriever will obtain exclusive locks
-    // on all pages (in case it is modified by US or another thread)
-    usearch_set_node_retriever(uidx, &ldb_wal_index_node_retriever, &ldb_wal_index_node_retriever_mut, &error);
-
-    assert(usearch_size(uidx, &error) == 0);
-    assert(!error);
 
     state = GenericXLogStart(index);
 
@@ -103,18 +150,12 @@ bool ldb_aminsert(Relation         index,
     EXTRA_DIRTIED = &extra_dirtied[ 0 ];
     EXTRA_DIRTIED_PAGE = &extra_dirtied_page[ 0 ];
     EXTRA_DIRTIED_SIZE = 0;
-    ldb_wal_retriever_area_init(BLCKSZ * 100);
 
     current_size = hdr->num_vectors;
 
     if(current_size >= HNSW_MAX_INDEXED_VECTORS) {
         elog(ERROR, "Index full. Cannot add more vectors. Current limit: %d", HNSW_MAX_INDEXED_VECTORS);
     }
-
-    // this reserves memory for internal structures,
-    // including for locks according to size indicated in usearch_mem
-    //  ^^ do not worry about allocaitng locks above. but that has to be eliminated down the line
-    usearch_view_mem_lazy(uidx, hdr->usearch_header, &error);
 
     usearch_reserve(uidx, current_size + 1, &error);
     int level = usearch_newnode_level(uidx, &error);
@@ -142,8 +183,7 @@ bool ldb_aminsert(Relation         index,
 
     usearch_update_header(uidx, hdr->usearch_header, &error);
 
-    usearch_free(uidx, &error);
-    ldb_wal_retriever_area_free();
+    ldb_wal_retriever_area_reset();
 
     MarkBufferDirty(hdr_buf);
     // we only release the header buffer AFTER inserting is finished to make sure nobody else changes the block
@@ -157,6 +197,7 @@ bool ldb_aminsert(Relation         index,
         MarkBufferDirty(extra_dirtied[ i ]);
         UnlockReleaseBuffer(extra_dirtied[ i ]);
     }
+    EXTRA_DIRTIED_SIZE = 0;
 
     UnlockReleaseBuffer(hdr_buf);
 

--- a/test/expected/hnsw_insert.out
+++ b/test/expected/hnsw_insert.out
@@ -62,12 +62,12 @@ psql:test/sql/hnsw_insert.sql:28: INFO:  usearch index initialized
  id  | dist 
 -----+------
  010 | 0.00
+ 010 | 0.00
+ 000 | 1.00
  000 | 1.00
  011 | 1.00
  110 | 1.00
- 001 | 1.41
- 100 | 1.41
- 111 | 1.41
+ xxx | 1.00
 (7 rows)
 
 INSERT INTO small_world (id, vector) VALUES 
@@ -93,12 +93,12 @@ psql:test/sql/hnsw_insert.sql:44: INFO:  usearch index initialized
  id  | dist 
 -----+------
  010 | 0.00
+ 010 | 0.00
+ 010 | 0.00
  000 | 1.00
  011 | 1.00
  110 | 1.00
- 001 | 1.41
- 100 | 1.41
- 111 | 1.41
+ 110 | 1.00
 (7 rows)
 
 SELECT v as v42 FROM sift_base1k WHERE id = 42 
@@ -208,12 +208,47 @@ psql:test/sql/hnsw_insert.sql:77: INFO:  usearch index initialized
  000 |  0.00
  000 |  0.00
  000 |  0.00
+ 000 |  0.00
  xxx |  0.00
  100 |  1.00
  010 |  1.00
  001 |  1.00
  100 |  1.00
  010 |  1.00
- 001 |  1.00
 (10 rows)
+
+select count(*) from sift_base1k;
+psql:test/sql/hnsw_insert.sql:79: INFO:  cost estimate
+ count 
+-------
+  1000
+(1 row)
+
+                                                       List of relations
+ Schema |            Name            | Type  |   Owner   |      Table      | Persistence | Access method |  Size  | Description 
+--------+----------------------------+-------+-----------+-----------------+-------------+---------------+--------+-------------
+ public | new_small_world_vector_idx | index | ngalstyan | new_small_world | permanent   | hnsw          | 176 kB | 
+ public | sift_base1k_pkey           | index | ngalstyan | sift_base1k     | permanent   | btree         | 40 kB  | 
+ public | sift_base1k_v_idx          | index | ngalstyan | sift_base1k     | permanent   | hnsw          | 872 kB | 
+ public | small_world_vector_idx     | index | ngalstyan | small_world     | permanent   | hnsw          | 176 kB | 
+(4 rows)
+
+INSERT INTO sift_base1k(v)
+SELECT v FROM sift_base1k WHERE id <= 444 AND v IS NOT NULL;
+INSERT 0 444
+select count(*) from sift_base1k;
+psql:test/sql/hnsw_insert.sql:83: INFO:  cost estimate
+ count 
+-------
+  1444
+(1 row)
+
+                                                        List of relations
+ Schema |            Name            | Type  |   Owner   |      Table      | Persistence | Access method |  Size   | Description 
+--------+----------------------------+-------+-----------+-----------------+-------------+---------------+---------+-------------
+ public | new_small_world_vector_idx | index | ngalstyan | new_small_world | permanent   | hnsw          | 176 kB  | 
+ public | sift_base1k_pkey           | index | ngalstyan | sift_base1k     | permanent   | btree         | 48 kB   | 
+ public | sift_base1k_v_idx          | index | ngalstyan | sift_base1k     | permanent   | hnsw          | 1168 kB | 
+ public | small_world_vector_idx     | index | ngalstyan | small_world     | permanent   | hnsw          | 176 kB  | 
+(4 rows)
 

--- a/test/expected/hnsw_insert.out
+++ b/test/expected/hnsw_insert.out
@@ -140,8 +140,8 @@ psql:test/sql/hnsw_insert.sql:52: INFO:  usearch index initialized
 ROLLBACK;
 ROLLBACK
 EXPLAIN SELECT id, ROUND((v <-> '[1,0,0,0,0,0,21,35,1,0,0,0,0,77,51,42,66,2,0,0,0,86,140,71,52,1,0,0,0,0,23,70,2,0,0,0,0,64,73,50,11,0,0,0,0,140,97,18,140,64,0,0,0,99,51,65,78,11,0,0,0,0,41,76,0,0,0,0,0,124,82,2,48,1,0,0,0,118,31,5,140,21,0,0,0,4,12,78,12,0,0,0,0,0,58,117,1,0,0,0,2,25,7,2,46,2,0,0,1,12,4,8,140,9,0,0,0,1,8,16,3,0,0,0,0,0,21,34]')::numeric, 2) FROM sift_base1k ORDER BY v <-> '[1,0,0,0,0,0,21,35,1,0,0,0,0,77,51,42,66,2,0,0,0,86,140,71,52,1,0,0,0,0,23,70,2,0,0,0,0,64,73,50,11,0,0,0,0,140,97,18,140,64,0,0,0,99,51,65,78,11,0,0,0,0,41,76,0,0,0,0,0,124,82,2,48,1,0,0,0,118,31,5,140,21,0,0,0,4,12,78,12,0,0,0,0,0,58,117,1,0,0,0,2,25,7,2,46,2,0,0,1,12,4,8,140,9,0,0,0,1,8,16,3,0,0,0,0,0,21,34]' LIMIT 10;
-psql:test/sql/hnsw_insert.sql:57: INFO:  cost estimate
-psql:test/sql/hnsw_insert.sql:57: INFO:  returning small cost to always use the index
+psql:test/sql/hnsw_insert.sql:56: INFO:  cost estimate
+psql:test/sql/hnsw_insert.sql:56: INFO:  returning small cost to always use the index
                                                                                                                                                                           QUERY PLAN                                                                                                                                                                          
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..0.14 rows=10 width=44)
@@ -150,11 +150,11 @@ psql:test/sql/hnsw_insert.sql:57: INFO:  returning small cost to always use the 
 (3 rows)
 
 SELECT id, ROUND((v <-> '[1,0,0,0,0,0,21,35,1,0,0,0,0,77,51,42,66,2,0,0,0,86,140,71,52,1,0,0,0,0,23,70,2,0,0,0,0,64,73,50,11,0,0,0,0,140,97,18,140,64,0,0,0,99,51,65,78,11,0,0,0,0,41,76,0,0,0,0,0,124,82,2,48,1,0,0,0,118,31,5,140,21,0,0,0,4,12,78,12,0,0,0,0,0,58,117,1,0,0,0,2,25,7,2,46,2,0,0,1,12,4,8,140,9,0,0,0,1,8,16,3,0,0,0,0,0,21,34]')::numeric, 2) FROM sift_base1k ORDER BY v <-> '[1,0,0,0,0,0,21,35,1,0,0,0,0,77,51,42,66,2,0,0,0,86,140,71,52,1,0,0,0,0,23,70,2,0,0,0,0,64,73,50,11,0,0,0,0,140,97,18,140,64,0,0,0,99,51,65,78,11,0,0,0,0,41,76,0,0,0,0,0,124,82,2,48,1,0,0,0,118,31,5,140,21,0,0,0,4,12,78,12,0,0,0,0,0,58,117,1,0,0,0,2,25,7,2,46,2,0,0,1,12,4,8,140,9,0,0,0,1,8,16,3,0,0,0,0,0,21,34]' LIMIT 10;
-psql:test/sql/hnsw_insert.sql:58: INFO:  cost estimate
-psql:test/sql/hnsw_insert.sql:58: INFO:  returning small cost to always use the index
-psql:test/sql/hnsw_insert.sql:58: INFO:  began scanning with 0 keys and 1 orderbys
-psql:test/sql/hnsw_insert.sql:58: INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
-psql:test/sql/hnsw_insert.sql:58: INFO:  usearch index initialized
+psql:test/sql/hnsw_insert.sql:57: INFO:  cost estimate
+psql:test/sql/hnsw_insert.sql:57: INFO:  returning small cost to always use the index
+psql:test/sql/hnsw_insert.sql:57: INFO:  began scanning with 0 keys and 1 orderbys
+psql:test/sql/hnsw_insert.sql:57: INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+psql:test/sql/hnsw_insert.sql:57: INFO:  usearch index initialized
  id  | round  
 -----+--------
   42 |   0.00
@@ -167,5 +167,53 @@ psql:test/sql/hnsw_insert.sql:58: INFO:  usearch index initialized
  340 | 295.40
  331 | 296.30
  682 | 308.20
+(10 rows)
+
+CREATE TABLE new_small_world as SELECT * from small_world;
+SELECT 26
+CREATE INDEX ON new_small_world USING hnsw (vector);
+psql:test/sql/hnsw_insert.sql:63: INFO:  done init usearch index
+psql:test/sql/hnsw_insert.sql:63: INFO:  inserted 26 elements
+psql:test/sql/hnsw_insert.sql:63: INFO:  done saving 26 vectors
+CREATE INDEX
+INSERT INTO new_small_world (id, vector) VALUES
+('000', '[0,0,0]'),
+('001', '[0,0,1]'),
+('010', '[0,1,0]'),
+('011', '[0,1,1]'),
+('100', '[1,0,0]'),
+('101', '[1,0,1]'),
+('110', '[1,1,0]'),
+('111', '[1,1,1]');
+INSERT 0 8
+SELECT '[0,0,0]'::vector as v42  
+EXPLAIN SELECT id, ROUND((vector <-> '[0,0,0]')::numeric, 2) FROM new_small_world ORDER BY vector <-> '[0,0,0]' LIMIT 10;
+psql:test/sql/hnsw_insert.sql:76: INFO:  cost estimate
+psql:test/sql/hnsw_insert.sql:76: INFO:  returning small cost to always use the index
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..1.64 rows=10 width=56)
+   ->  Index Scan using new_small_world_vector_idx on new_small_world  (cost=0.00..4.27 rows=26 width=56)
+         Order By: (vector <-> '[0,0,0]'::vector)
+(3 rows)
+
+SELECT id, ROUND((vector <-> '[0,0,0]')::numeric, 2) FROM new_small_world ORDER BY vector <-> '[0,0,0]' LIMIT 10;
+psql:test/sql/hnsw_insert.sql:77: INFO:  cost estimate
+psql:test/sql/hnsw_insert.sql:77: INFO:  returning small cost to always use the index
+psql:test/sql/hnsw_insert.sql:77: INFO:  began scanning with 0 keys and 1 orderbys
+psql:test/sql/hnsw_insert.sql:77: INFO:  starting scan with dimensions=3 M=16 efConstruction=128 ef=64
+psql:test/sql/hnsw_insert.sql:77: INFO:  usearch index initialized
+ id  | round 
+-----+-------
+ 000 |  0.00
+ 000 |  0.00
+ 000 |  0.00
+ xxx |  0.00
+ 100 |  1.00
+ 010 |  1.00
+ 001 |  1.00
+ 100 |  1.00
+ 010 |  1.00
+ 001 |  1.00
 (10 rows)
 

--- a/test/expected/wiki.out
+++ b/test/expected/wiki.out
@@ -86,7 +86,7 @@ with t as (select id, page_title,  context_page_description_ai <-> (select conte
  81846 | Frank Carlucci                       |  7.25
 (10 rows)
 
-CREATE INDEX ON tsv_data USING hnsw (context_page_description_ai vector_l2_ops);
+CREATE INDEX index1 ON tsv_data USING hnsw (context_page_description_ai vector_l2_ops);
 psql:test/sql/wiki.sql:66: INFO:  done init usearch index
 psql:test/sql/wiki.sql:66: INFO:  inserted 100 elements
 psql:test/sql/wiki.sql:66: INFO:  done saving 100 vectors
@@ -104,14 +104,14 @@ psql:test/sql/wiki.sql:71: INFO:  cost estimate
 psql:test/sql/wiki.sql:71: INFO:  returning small cost to always use the index
 psql:test/sql/wiki.sql:71: INFO:  cost estimate
 psql:test/sql/wiki.sql:71: INFO:  returning small cost to always use the index
-                                                       QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
+                                                       QUERY PLAN                                                       
+------------------------------------------------------------------------------------------------------------------------
  Subquery Scan on t  (cost=8.16..8.74 rows=10 width=68)
    ->  Limit  (cost=8.16..8.59 rows=10 width=44)
          InitPlan 1 (returns $0)
            ->  Index Scan using tsv_data_pkey on tsv_data tsv_data_1  (cost=0.14..8.16 rows=1 width=32)
                  Index Cond: (id = 81386)
-         ->  Index Scan using tsv_data_context_page_description_ai_idx1 on tsv_data  (cost=0.00..4.26 rows=100 width=44)
+         ->  Index Scan using tsv_data_context_page_description_ai_idx on tsv_data  (cost=0.00..4.26 rows=100 width=44)
                Order By: (context_page_description_ai <-> $0)
 (7 rows)
 
@@ -137,4 +137,23 @@ psql:test/sql/wiki.sql:75: INFO:  usearch index initialized
  95386 | Alexandre Étienne Choron             |  7.14
  81846 | Frank Carlucci                       |  7.25
 (10 rows)
+
+drop index index1;
+DROP INDEX
+select count(*) from tsv_data;
+psql:test/sql/wiki.sql:79: INFO:  cost estimate
+ count 
+-------
+   100
+(1 row)
+
+INSERT INTO tsv_data(context_page_description_ai)
+SELECT context_page_description_ai FROM tsv_data WHERE context_page_description_ai IS NOT NULL LIMIT 444;
+INSERT 0 100
+select count(*) from tsv_data;
+psql:test/sql/wiki.sql:82: INFO:  cost estimate
+ count 
+-------
+   200
+(1 row)
 

--- a/test/sql/hnsw_insert.sql
+++ b/test/sql/hnsw_insert.sql
@@ -75,3 +75,11 @@ INSERT INTO new_small_world (id, vector) VALUES
 SELECT '[0,0,0]'::vector as v42  \gset
 EXPLAIN SELECT id, ROUND((vector <-> :'v42')::numeric, 2) FROM new_small_world ORDER BY vector <-> :'v42' LIMIT 10;
 SELECT id, ROUND((vector <-> :'v42')::numeric, 2) FROM new_small_world ORDER BY vector <-> :'v42' LIMIT 10;
+
+select count(*) from sift_base1k;
+\di+
+INSERT INTO sift_base1k(v)
+SELECT v FROM sift_base1k WHERE id <= 444 AND v IS NOT NULL;
+select count(*) from sift_base1k;
+\di+
+

--- a/test/sql/hnsw_insert.sql
+++ b/test/sql/hnsw_insert.sql
@@ -52,9 +52,26 @@ EXPLAIN SELECT id, ROUND((v <-> :'v42')::numeric, 2) FROM sift_base1k ORDER BY v
 SELECT id, ROUND((v <-> :'v42')::numeric, 2) FROM sift_base1k ORDER BY v <-> :'v42' LIMIT 10;
 ROLLBACK;
 
-
 -- index scan
 EXPLAIN SELECT id, ROUND((v <-> :'v42')::numeric, 2) FROM sift_base1k ORDER BY v <-> :'v42' LIMIT 10;
 SELECT id, ROUND((v <-> :'v42')::numeric, 2) FROM sift_base1k ORDER BY v <-> :'v42' LIMIT 10;
-
 -- todo:: craft an SQL query to compare the results of the two above so I do not have to do it manually
+
+
+-- another insert test
+CREATE TABLE new_small_world as SELECT * from small_world;
+CREATE INDEX ON new_small_world USING hnsw (vector);
+
+INSERT INTO new_small_world (id, vector) VALUES
+('000', '[0,0,0]'),
+('001', '[0,0,1]'),
+('010', '[0,1,0]'),
+('011', '[0,1,1]'),
+('100', '[1,0,0]'),
+('101', '[1,0,1]'),
+('110', '[1,1,0]'),
+('111', '[1,1,1]');
+-- index scan
+SELECT '[0,0,0]'::vector as v42  \gset
+EXPLAIN SELECT id, ROUND((vector <-> :'v42')::numeric, 2) FROM new_small_world ORDER BY vector <-> :'v42' LIMIT 10;
+SELECT id, ROUND((vector <-> :'v42')::numeric, 2) FROM new_small_world ORDER BY vector <-> :'v42' LIMIT 10;

--- a/test/sql/wiki.sql
+++ b/test/sql/wiki.sql
@@ -63,7 +63,7 @@ ALTER TABLE ONLY tsv_data
 with t as (select id, page_title,  context_page_description_ai <-> (select context_page_description_ai from tsv_data where id = 81386) as dist
  from tsv_data order by dist
  limit 10) select id, page_title, ROUND( dist::numeric, 2) from t;
-CREATE INDEX ON tsv_data USING hnsw (context_page_description_ai vector_l2_ops);
+CREATE INDEX index1 ON tsv_data USING hnsw (context_page_description_ai vector_l2_ops);
 CREATE INDEX ON tsv_data USING hnsw (context_page_description_ai) with (ef = 100, ef_construction=150 , M=11, alg="hnswlib");
 set enable_seqscan=false;
 
@@ -73,3 +73,10 @@ explain with t as (select id, page_title, context_page_description_ai <-> (selec
 -- introduce a WITH statement to round returned distances AFTER a lookup so the index can be used
 with t as (select id, page_title, context_page_description_ai <-> (select context_page_description_ai from tsv_data where id = 81386) as dist
  from tsv_data order by dist limit 10) select id, page_title, ROUND( dist::numeric, 2) from t;
+
+-- test additional inserts on wiki table
+drop index index1;
+select count(*) from tsv_data;
+INSERT INTO tsv_data(context_page_description_ai)
+SELECT context_page_description_ai FROM tsv_data WHERE context_page_description_ai IS NOT NULL LIMIT 444;
+select count(*) from tsv_data;


### PR DESCRIPTION
- [x] Cache and reuse some context across inserts in an insert query
- [ ] Replace o(index_size) linear block retriever index with a postgres hash table
- [ ] Break down the contiguous and fixed size index header blocks into dynamic array