### PR TITLE
[FEATURE]: Dockerfile and Docker build action

### DIFF
--- a/.github/workflows/build-and-test-linux.yaml
+++ b/.github/workflows/build-and-test-linux.yaml
@@ -1,0 +1,37 @@
+name: build
+on:
+  push:
+  pull_request:
+jobs:
+  ubuntu:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - postgres: 15
+            os: ubuntu-22.04
+          - postgres: 14
+            os: ubuntu-22.04
+          - postgres: 13
+            os: ubuntu-22.04
+          - postgres: 12
+            os: ubuntu-22.04
+          - postgres: 11
+            os: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - name: Build
+        run: sudo su -c "PG_VERSION=$PG_VERSION USE_SOURCE=1 ./ci/scripts/build-linux.sh"
+        env:
+          PG_VERSION: ${{ matrix.postgres }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
+      - name: Run tests
+        run: sudo su postgres -c "PG_VERSION=$PG_VERSION ./ci/scripts/run-tests.sh"
+        env:
+          PG_VERSION: ${{ matrix.postgres }}

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -1,0 +1,44 @@
+name: publish-docker
+on:
+  workflow_dispatch:
+    inputs:
+      VERSION:
+        type: string
+        description: "Extension version"
+        required: true
+        default: "0.1"
+      PG_VERSION:
+        type: string
+        description: "Version of the postgres image"
+        required: true
+        default: "15"
+      IMAGE_NAME:
+        type: string
+        description: "Container image name to tag"
+        required: true
+        default: "lanterndata/lanterndb"
+jobs:
+  ubuntu:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            PG_VERSION=${{ inputs.PG_VERSION }}
+          tags: ${{ inputs.IMAGE_NAME}}:latest,${{ inputs.IMAGE_NAME }}:${{ inputs.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+ARG PG_VERSION=15
+FROM postgres:$PG_VERSION
+ARG PG_VERSION
+
+COPY . /tmp/lanterndb
+
+RUN PG_VERSION=$PG_VERSION ./tmp/lanterndb/ci/scripts/build-docker.sh 

--- a/ci/scripts/build-docker.sh
+++ b/ci/scripts/build-docker.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+get_cmake_flags(){
+ # TODO:: remove after test
+ echo "-DUSEARCH_NO_MARCH_NATIVE=ON"
+ # if [[ $ARCH == *"arm"* ]]; then
+ #   echo "-DUSEARCH_NO_MARCH_NATIVE=ON"
+ # fi
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+if [ -z "$PG_VERSION" ]
+then
+  export PG_VERSION=15
+fi
+
+# Set Locale
+apt update && apt-mark hold locales && \
+# Install required packages for build
+apt install -y --no-install-recommends build-essential cmake postgresql-server-dev-$PG_VERSION postgresql-$PG_VERSION-pgvector && \
+# Build lanterndb
+cd /tmp/lanterndb && mkdir build && cd build && \
+# Run cmake
+sh -c "cmake $(get_cmake_flags) .." && \
+make install && \
+# Remove dev files
+rm -rf /tmp/lanterndb && \
+apt-get remove -y build-essential postgresql-server-dev-$PG_VERSION cmake && \
+apt-get autoremove -y && \
+apt-mark unhold locales && \
+rm -rf /var/lib/apt/lists/*

--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+get_cmake_flags(){
+ # TODO:: remove after test
+ echo "-DUSEARCH_NO_MARCH_NATIVE=ON"
+ # if [[ $ARCH == *"arm"* ]]; then
+ #   echo "-DUSEARCH_NO_MARCH_NATIVE=ON"
+ # fi
+}
+
+export BRANCH=$BRANCH_NAME
+export POSTGRES_USER=postgres
+export DEBIAN_FRONTEND=noninteractive
+
+if [ -z "$BRANCH" ]
+then
+  BRANCH="dev"
+fi
+
+if [ -z "$PG_VERSION" ]
+then
+  export PG_VERSION=15
+fi
+
+# Set Locale
+echo "LC_ALL=en_US.UTF-8" > /etc/environment && \
+echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+echo "LANG=en_US.UTF-8" > /etc/locale.conf && \
+apt update -y && apt install locales -y && \
+locale-gen en_US.UTF-8 && \
+# Install required packages for build
+apt install lsb-core build-essential automake cmake wget git dpkg-dev wget -y && \
+# Add postgresql apt repo
+export ARCH=$(dpkg-architecture -q DEB_BUILD_ARCH) && \
+sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc |  apt-key add - &&\
+# Install postgres and dev files for C headers
+apt update && apt install postgresql-$PG_VERSION postgresql-server-dev-$PG_VERSION -y
+# Install pgvector
+apt install postgresql-$PG_VERSION-pgvector -y
+# Fix pg_config (sometimes it points to wrong version)
+rm -f /usr/bin/pg_config && ln -s /usr/lib/postgresql/$PG_VERSION/bin/pg_config /usr/bin/pg_config
+
+if [ -z ${USE_SOURCE+x} ]; then
+  # Clone from git
+  cd /tmp && git clone --recursive https://github.com/lanterndata/lanterndb.git -b $BRANCH
+else 
+  # Use already checkouted code
+  mkdir -p /tmp/lanterndb && cp -r ./* /tmp/lanterndb/
+fi
+
+cd /tmp/lanterndb && mkdir build && cd build && \
+# Run cmake
+sh -c "cmake $(get_cmake_flags) .." && \
+make install && \
+# Remove apt cache
+apt-get clean && \
+chown -R postgres:postgres /tmp/lanterndb

--- a/ci/scripts/run-tests.sh
+++ b/ci/scripts/run-tests.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+wait_for_pg(){
+ tries=0
+ until pg_isready -U postgres 2>/dev/null; do
+   if [ $tries -eq 10 ];
+   then
+     echo "Can not connect to postgres"
+     exit 1
+   fi
+   
+   sleep 1
+   tries=$((tries+1))
+ done
+}
+
+export WORKDIR=/tmp/lanterndb
+
+if [ -z "$PG_VERSION" ]
+then
+  export PG_VERSION=15
+fi
+
+export PGDATA=/etc/postgresql/$PG_VERSION/main/
+# Set port
+echo "port = 5432" >> $PGDATA/postgresql.conf
+# Run postgres database
+POSTGRES_HOST_AUTH_METHOD=trust /usr/lib/postgresql/$PG_VERSION/bin/postgres &>/dev/null &
+# Wait for start and run tests
+wait_for_pg && cd $WORKDIR/build && make test


### PR DESCRIPTION
## Description
- Added `Dockerfile` which will build the `lanterndb` with specified version of `postgres` database.

- Added Github Action which can be triggered manually. 

The action accepts the following inputs:

 `VERSION` - extension version: e.g `0.1`
 `PG_VERSION` - postgres version to build with e.g. `15`
`IMAGE_NAME` - dockerhub image name under which the image will be pushed e.g `lanterndata/lanterndb`

To build the image locally you can run:

```
docker build . -t lanterndata/lanterndb
```

Then you can run the image as usual postgres image:
```
docker run -ti --name lanterndb --rm -e "POSTGRES_PASSWORD=postgres" lanterndata/lanterndb
```

It is needed to add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` Action secrets to the repository in order to push the image to dockerhub.

Example of the action can be found at: https://github.com/var77/lanterndb/actions/runs/5700279469/job/15449972964 

The action was triggered manually with command
```
gh workflow run .github/workflows/publish-docker.yaml -f VERSION=0.1 -f PG_VERSION=15 -f IMAGE_NAME=varik77/lanterndb --repo var77/lanterndb --ref feature/dockerfile
```

This branch was created from [feature/ci-cd](https://github.com/var77/lanterndb/tree/feature/ci-cd) so you may consider merging [this PR](https://github.com/lanterndata/lanterndb/pull/2) first