### PR TITLE
[FEATURE]: Dockerfile and Docker build action

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -1,0 +1,44 @@
+name: publish-docker
+on:
+  workflow_dispatch:
+    inputs:
+      VERSION:
+        type: string
+        description: "Extension version"
+        required: true
+        default: "0.1"
+      PG_VERSION:
+        type: string
+        description: "Version of the postgres image"
+        required: true
+        default: "15"
+      IMAGE_NAME:
+        type: string
+        description: "Container image name to tag"
+        required: true
+        default: "lanterndata/lanterndb"
+jobs:
+  ubuntu:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            PG_VERSION=${{ inputs.PG_VERSION }}
+          tags: ${{ inputs.IMAGE_NAME}}:latest,${{ inputs.IMAGE_NAME }}:${{ inputs.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+ARG PG_VERSION=15
+FROM postgres:$PG_VERSION
+ARG PG_VERSION
+
+COPY . /tmp/lanterndb
+
+RUN PG_VERSION=$PG_VERSION ./tmp/lanterndb/ci/scripts/build-docker.sh 

--- a/ci/scripts/build-docker.sh
+++ b/ci/scripts/build-docker.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+get_cmake_flags(){
+ # TODO:: remove after test
+ echo "-DUSEARCH_NO_MARCH_NATIVE=ON"
+ # if [[ $ARCH == *"arm"* ]]; then
+ #   echo "-DUSEARCH_NO_MARCH_NATIVE=ON"
+ # fi
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+if [ -z "$PG_VERSION" ]
+then
+  export PG_VERSION=15
+fi
+
+# Set Locale
+apt update && apt-mark hold locales && \
+# Install required packages for build
+apt install -y --no-install-recommends build-essential cmake postgresql-server-dev-$PG_VERSION postgresql-$PG_VERSION-pgvector && \
+# Build lanterndb
+cd /tmp/lanterndb && mkdir build && cd build && \
+# Run cmake
+sh -c "cmake $(get_cmake_flags) .." && \
+make install && \
+# Remove dev files
+rm -rf /tmp/lanterndb && \
+apt-get remove -y build-essential postgresql-server-dev-$PG_VERSION cmake && \
+apt-get autoremove -y && \
+apt-mark unhold locales && \
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description
- Added `Dockerfile` which will build the `lanterndb` with specified version of `postgres` database.

- Added Github Action which can be triggered manually. 

The action accepts the following inputs:

 `VERSION` - extension version: e.g `0.1`
 `PG_VERSION` - postgres version to build with e.g. `15`
`IMAGE_NAME` - dockerhub image name under which the image will be pushed e.g `lanterndata/lanterndb`

To build the image locally you can run:

```
docker build . -t lanterndata/lanterndb
```

Then you can run the image as usual postgres image:
```
docker run -ti --name lanterndb --rm -e "POSTGRES_PASSWORD=postgres" lanterndata/lanterndb
```

It is needed to add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` Action secrets to the repository in order to push the image to dockerhub.

Example of the action can be found at: https://github.com/var77/lanterndb/actions/runs/5700279469/job/15449972964 

The action was triggered manually with command
```
gh workflow run .github/workflows/publish-docker.yaml -f VERSION=0.1 -f PG_VERSION=15 -f IMAGE_NAME=varik77/lanterndb --repo var77/lanterndb --ref feature/dockerfile
```

This branch was created from [feature/ci-cd](https://github.com/var77/lanterndb/tree/feature/ci-cd) so you may consider merging [this PR](https://github.com/lanterndata/lanterndb/pull/2) first