### PR TITLE
[FEATURE]: Added debian releases

### DIFF
--- a/.github/workflows/build-and-test-linux.yaml
+++ b/.github/workflows/build-and-test-linux.yaml
@@ -30,7 +30,8 @@ jobs:
         with:
           submodules: "recursive"
       - name: Build
-        run: sudo su -c "PG_VERSION=$PG_VERSION USE_SOURCE=1 ./ci/scripts/build-linux.sh"
+        id: build
+        run: sudo su -c "PG_VERSION=$PG_VERSION USE_SOURCE=1 GITHUB_OUTPUT=$GITHUB_OUTPUT ./ci/scripts/build-linux.sh"
         env:
           PG_VERSION: ${{ matrix.postgres }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -41,3 +42,8 @@ jobs:
         run: sudo su postgres -c "PG_VERSION=$PG_VERSION ./ci/scripts/run-tests.sh"
         env:
           PG_VERSION: ${{ matrix.postgres }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.build.outputs.package_name }}
+          path: ${{ steps.build.outputs.package_path }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,3 +173,11 @@ add_custom_target(
   COMMAND ${CMAKE_SOURCE_DIR}/scripts/bench.sh
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
  )
+
+# Debian packaging
+string(REGEX MATCH "^PostgreSQL (\[0-9]+).*"
+  PostgreSQL_VERSION_NUMBER ${PostgreSQL_VERSION_STRING})
+set(CPACK_GENERATOR "DEB")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "postgresql-${CMAKE_MATCH_1}, postgresql-${CMAKE_MATCH_1}-pgvector")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Lantern Data")
+include(CPack)

--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -22,6 +22,11 @@ then
   export PG_VERSION=15
 fi
 
+if [ -z "$GITHUB_OUTPUT" ]
+then
+  export GITHUB_OUTPUT=/dev/null
+fi
+
 # Set Locale
 echo "LC_ALL=en_US.UTF-8" > /etc/environment && \
 echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
@@ -53,6 +58,14 @@ cd /tmp/lanterndb && mkdir build && cd build && \
 # Run cmake
 sh -c "cmake $(get_cmake_flags) .." && \
 make install && \
-# Remove apt cache
-apt-get clean && \
+# Bundle debian packages && \
+cpack &&
+ 
+# Print package name to github output
+export EXT_VERSION=$(cmake --system-information | awk -F= '$1~/CMAKE_PROJECT_VERSION:STATIC/{print$2}') && \
+export PACKAGE_NAME=lanterndb-${EXT_VERSION}-postgres-${PG_VERSION}-${ARCH}.deb && \
+echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT" && \
+echo "package_path=$(pwd)/$(ls *.deb | tr -d '\n')" >> "$GITHUB_OUTPUT"
+
+# Chown to postgres for running tests
 chown -R postgres:postgres /tmp/lanterndb


### PR DESCRIPTION
## Description
Add packaging with `cpack` and upload the packaged `.deb` file to action output artifacts.

Currently only `amd64` packages are being generated, in future we will add `arm` runners and release packages for arm architecture as well.

The action output will contain `deb` packages as shown in screenshot

[Example action run](https://github.com/lanterndata/lanterndb/actions/runs/5702619345)

![image](https://github.com/lanterndata/lanterndb/assets/17221195/e161a01b-f2ec-4935-b2b5-44cabdbe3419)