### PR TITLE
[FEATURE]: Added debian and archive releases

### DIFF
--- a/.github/workflows/build-and-test-linux.yaml
+++ b/.github/workflows/build-and-test-linux.yaml
@@ -9,7 +9,7 @@ on:
       - main
       - dev
 jobs:
-  ubuntu:
+  ubuntu-build:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -30,14 +30,46 @@ jobs:
         with:
           submodules: "recursive"
       - name: Build
-        run: sudo su -c "PG_VERSION=$PG_VERSION USE_SOURCE=1 ./ci/scripts/build-linux.sh"
+        id: build
+        run: sudo su -c "PG_VERSION=$PG_VERSION USE_SOURCE=1 GITHUB_OUTPUT=$GITHUB_OUTPUT ./ci/scripts/build-linux.sh"
         env:
           PG_VERSION: ${{ matrix.postgres }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-      # Enable tmate debugging of manually-triggered workflows if the input option was provided
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
+      - name: Create Archive Package
+        id: archive
+        run: sudo su -c "GITHUB_OUTPUT=$GITHUB_OUTPUT ./ci/scripts/package-archive.sh"
       - name: Run tests
         run: sudo su postgres -c "PG_VERSION=$PG_VERSION ./ci/scripts/run-tests.sh"
         env:
           PG_VERSION: ${{ matrix.postgres }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.build.outputs.package_name }}
+          path: ${{ steps.build.outputs.package_path }}
+      - name: Upload archive package artifacts
+        uses: actions/upload-artifact@v3
+        if: ${{ steps.archive.outputs.archive_package_name != '' }}
+        with:
+          name: lanterndb-package
+          path: ${{ steps.archive.outputs.archive_package_path }}
+  ubuntu-package:
+    runs-on: ubuntu-22.04
+    needs: [ubuntu-build]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: lanterndb-package
+          path: /tmp/lanterndb-package
+      - name: Create universal package
+        id: package
+        run: sudo su -c "GITHUB_OUTPUT=$GITHUB_OUTPUT ./ci/scripts/universal-package.sh"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.package.outputs.package_name }}
+          path: ${{ steps.package.outputs.package_path }}
+      - uses: geekyeggo/delete-artifact@v2
+        with:
+          name: lanterndb-package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,3 +180,21 @@ add_custom_target(
   COMMAND ${CMAKE_SOURCE_DIR}/scripts/bench.sh
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
  )
+
+# Package universal install script
+string(REGEX MATCH "^PostgreSQL (\[0-9]+).*"
+  PostgreSQL_VERSION_NUMBER ${PostgreSQL_VERSION_STRING})
+
+add_custom_target(
+  archive
+  ${CMAKE_COMMAND} -E env SOURCE_DIR=${CMAKE_SOURCE_DIR} BUILD_DIR=${CMAKE_BINARY_DIR} PG_VERSION=${CMAKE_MATCH_1} ${CMAKE_SOURCE_DIR}/scripts/package.sh
+  DEPENDS ${CMAKE_BINARY_DIR}/${_script_file}
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+add_dependencies(archive lanterndb)
+
+# Debian packaging
+set(CPACK_GENERATOR "DEB")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "postgresql-${CMAKE_MATCH_1}, postgresql-${CMAKE_MATCH_1}-pgvector")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Lantern Data")
+include(CPack)

--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -22,6 +22,11 @@ then
   export PG_VERSION=15
 fi
 
+if [ -z "$GITHUB_OUTPUT" ]
+then
+  export GITHUB_OUTPUT=/dev/null
+fi
+
 # Set Locale
 echo "LC_ALL=en_US.UTF-8" > /etc/environment && \
 echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
@@ -53,6 +58,16 @@ cd /tmp/lanterndb && mkdir build && cd build && \
 # Run cmake
 sh -c "cmake $(get_cmake_flags) .." && \
 make install && \
-# Remove apt cache
-apt-get clean && \
+# Bundle debian packages && \
+cpack &&
+ 
+# Print package name to github output
+export EXT_VERSION=$(cmake --system-information | awk -F= '$1~/CMAKE_PROJECT_VERSION:STATIC/{print$2}') && \
+export PACKAGE_NAME=lanterndb-${EXT_VERSION}-postgres-${PG_VERSION}-${ARCH}.deb && \
+
+echo "package_version=$EXT_VERSION" >> "$GITHUB_OUTPUT" && \
+echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT" && \
+echo "package_path=$(pwd)/$(ls *.deb | tr -d '\n')" >> "$GITHUB_OUTPUT"
+
+# Chown to postgres for running tests
 chown -R postgres:postgres /tmp/lanterndb

--- a/ci/scripts/package-archive.sh
+++ b/ci/scripts/package-archive.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ -z "$GITHUB_OUTPUT" ]
+then
+  export GITHUB_OUTPUT=/dev/null
+fi
+
+cd /tmp/lanterndb/build && make archive
+cat /tmp/gh-output.txt >> $GITHUB_OUTPUT && rm -rf /tmp/gh-output

--- a/ci/scripts/universal-package.sh
+++ b/ci/scripts/universal-package.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+if [ -z "$GITHUB_OUTPUT" ]
+then
+  export GITHUB_OUTPUT=/dev/null
+fi
+
+PACKAGE_DIR=/tmp/lanterndb-package
+PACKAGE_VERSION=$(ls -t $PACKAGE_DIR | head -1 | sed -E "s#lanterndb-(.*)-postgres.*#\1#")
+PACKAGE_NAME=lanterndb-${PACKAGE_VERSION}
+OUTPUT_DIR=/tmp/$PACKAGE_NAME
+SHARED_DIR=${OUTPUT_DIR}/shared
+mkdir $OUTPUT_DIR
+
+cd $PACKAGE_DIR
+for f in $(find "." -name "*.tar"); do
+    current_archive_name=$(echo $f | sed -E 's#(.*).tar#\1#')   
+    current_pg_version=$(echo $current_archive_name | sed -E 's#(.*)-postgres-(.*)-(.*)#\2#')   
+    current_arch=$(echo $current_archive_name | sed -E 's#(.*)-postgres-(.*)-(.*)#\3#')   
+    current_dest_folder=${OUTPUT_DIR}/src/${current_arch}/${current_pg_version}
+
+    tar xf $f
+
+    if [ ! -d "$SHARED_DIR" ]; then
+      # Copying static files which does not depend to architecture and pg version only once
+      mkdir -p $SHARED_DIR
+      cp $current_archive_name/Makefile $OUTPUT_DIR/
+      cp $current_archive_name/*.sh $OUTPUT_DIR/
+      cp $current_archive_name/src/*.sql $SHARED_DIR/
+      cp $current_archive_name/src/*.control $SHARED_DIR/
+    fi
+
+    mkdir -p $current_dest_folder
+    cp $current_archive_name/src/*.so $current_dest_folder/
+done
+
+cd /tmp && tar cf ${PACKAGE_NAME}.tar $PACKAGE_NAME
+echo "package_name=${PACKAGE_NAME}.tar" >> $GITHUB_OUTPUT
+echo "package_path=/tmp/${PACKAGE_NAME}.tar" >> $GITHUB_OUTPUT

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+cd $BUILD_DIR
+ARCH=$(dpkg-architecture -q DEB_BUILD_ARCH)
+EXT_VERSION=$(cmake --system-information | awk -F= '$1~/CMAKE_PROJECT_VERSION:STATIC/{print$2}')
+PACKAGE_NAME=lanterndb-${EXT_VERSION}-postgres-${PG_VERSION}-${ARCH}
+
+mkdir -p ${BUILD_DIR}/${PACKAGE_NAME}/src
+cp ${SOURCE_DIR}/scripts/packaging/* ${BUILD_DIR}/${PACKAGE_NAME}/
+cp ${BUILD_DIR}/*.so ${BUILD_DIR}/${PACKAGE_NAME}/src
+cp ${BUILD_DIR}/*.sql ${BUILD_DIR}/${PACKAGE_NAME}/src
+
+for f in $(find "${SOURCE_DIR}/sql/updates/" -name "*.sql"); do
+    dest_filename=$(echo $f | sed -E 's#(.*)/(.*\.sql)#lanterndb--\2#g')
+    cp $f ${BUILD_DIR}/${PACKAGE_NAME}/src/${dest_filename}
+done
+
+cp ${SOURCE_DIR}/lanterndb.control ${BUILD_DIR}/${PACKAGE_NAME}/src
+
+cd ${BUILD_DIR} && tar cf ${PACKAGE_NAME}.tar ${PACKAGE_NAME}
+rm -rf ${BUILD_DIR}/${PACKAGE_NAME}
+
+## Write output so we can use this in actions and upload artifacts
+echo "archive_package_name=${PACKAGE_NAME}.tar" >> "/tmp/gh-output.txt"
+echo "archive_package_path=${BUILD_DIR}/${PACKAGE_NAME}.tar" >> "/tmp/gh-output.txt"

--- a/scripts/packaging/Makefile
+++ b/scripts/packaging/Makefile
@@ -1,0 +1,6 @@
+help:
+	@echo "PG_CONFIG=/path/to/pg_config ARCH=arm64 make install"
+install:
+	@./install.sh
+uninstall:
+	@./uninstall.sh

--- a/scripts/packaging/install.sh
+++ b/scripts/packaging/install.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+if [ -z "$PG_CONFIG" ]
+then
+  if ! command -v pg_config &> /dev/null
+  then
+    echo "pg_config could not be found. Please specify with PG_CONFIG env variable"
+    exit
+  fi
+  PG_CONFIG=$(which pg_config)
+fi
+
+if [ -z "$ARCH" ]
+then
+  if command -v dpkg &> /dev/null
+  then
+    ARCH=$(dpkg --print-architecture)
+  elif command -v apk &> /dev/null
+  then
+    ARCH=$(apk --print-arch)
+  elif command -v uname &> /dev/null
+  then
+    ARCH=$(uname -m)
+  else
+    echo "Could not detect system architecture. Please specify with ARCH env variable"
+    exit
+  fi
+fi
+
+PG_LIBRARY_DIR=$($PG_CONFIG --pkglibdir)
+PG_EXTENSION_DIR=$($PG_CONFIG --sharedir)/extension
+PG_VERSION_STRING=$($PG_CONFIG --version)
+PG_VERSION=$(echo $PG_VERSION_STRING | sed -E "s#^PostgreSQL ([0-9]+).*#\1#")
+
+if [ ! -d src/${ARCH} ]
+then
+  echo "Architecture $ARCH not supported. Try building from source"
+  exit
+fi
+
+if [ ! -d src/${ARCH}/${PG_VERSION} ]
+then
+  echo "Postgres version $PG_VERSION not supported"
+  exit
+fi
+
+cp -r src/${ARCH}/${PG_VERSION}/*.so $PG_LIBRARY_DIR
+cp -r shared/*.sql $PG_EXTENSION_DIR
+cp -r shared/*.control $PG_EXTENSION_DIR
+
+echo "LanternDB installed successfully"

--- a/scripts/packaging/uninstall.sh
+++ b/scripts/packaging/uninstall.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ -z "$PG_CONFIG" ]
+then
+  if ! command -v pg_config &> /dev/null
+  then
+    echo "pg_config could not be found. Please specify with PG_CONFIG env variable"
+    exit
+  fi
+  PG_CONFIG=$(which pg_config)
+fi
+
+PG_LIBRARY_DIR=$($PG_CONFIG --pkglibdir)
+PG_EXTENSION_DIR=$($PG_CONFIG --sharedir)/extension
+
+rm -rf $PG_LIBRARY_DIR/lanterndb*.so
+rm -rf $PG_EXTENSION_DIR/lanterndb*.sql
+rm -rf $PG_EXTENSION_DIR/lanterndb.control
+
+echo "LanternDB uninstalled successfully"


### PR DESCRIPTION
## Description
- Add packaging with `cpack` and upload the packaged `.deb` file to action output artifacts.
- Added archive packaging which will create `tar` archive.

The action output will contain `deb` packages and `tar` universal package as shown in screenshot
Currently only `amd64` packages are being generated

## Installation

To install from `deb` package, download the package and run

```
dpkg -i lanterndb-0.0.2-postgres-15-amd64.deb
```
Assuming you have already installed `postgres` and `pgvector` of the specified version

To install from universal archive package download the tar archive and run

```
tar xvf lanterndb-0.0.2.tar && \
cd lanterndb-0.0.2 && \ 
make install
```

[Example action run](https://github.com/lanterndata/lanterndb/actions/runs/5705993263)

![image](https://github.com/lanterndata/lanterndb/assets/17221195/1221a592-fc48-4d65-a027-30b6a5f0d8b2)