### PR TITLE
[FEATURE]: separate workflow files, add test coverage

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -31,17 +31,13 @@ jobs:
           submodules: "recursive"
       - name: Build
         id: build
-        run: sudo su -c "PG_VERSION=$PG_VERSION USE_SOURCE=1 GITHUB_OUTPUT=$GITHUB_OUTPUT ./ci/scripts/build-linux.sh"
+        run: sudo su -c "PG_VERSION=$PG_VERSION USE_SOURCE=1 GITHUB_OUTPUT=$GITHUB_OUTPUT BUILD_PACKAGES=1 ./ci/scripts/build-linux.sh"
         env:
           PG_VERSION: ${{ matrix.postgres }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       - name: Create Archive Package
         id: archive
         run: sudo su -c "GITHUB_OUTPUT=$GITHUB_OUTPUT ./ci/scripts/package-archive.sh"
-      - name: Run tests
-        run: sudo su postgres -c "PG_VERSION=$PG_VERSION ./ci/scripts/run-tests.sh"
-        env:
-          PG_VERSION: ${{ matrix.postgres }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -1,0 +1,71 @@
+name: test
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: "Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)"
+        required: false
+        default: false
+jobs:
+  ubuntu-build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - postgres: 15
+            os: ubuntu-22.04
+          - postgres: 14
+            os: ubuntu-22.04
+          - postgres: 13
+            os: ubuntu-22.04
+          - postgres: 12
+            os: ubuntu-22.04
+          - postgres: 11
+            os: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - name: Build
+        id: build
+        run: sudo su -c "PG_VERSION=$PG_VERSION USE_SOURCE=1 GITHUB_OUTPUT=$GITHUB_OUTPUT ENABLE_COVERAGE=1 ./ci/scripts/build-linux.sh"
+        env:
+          PG_VERSION: ${{ matrix.postgres }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+      - name: Run tests
+        id: test
+        run: sudo su postgres -c "PG_VERSION=$PG_VERSION ./ci/scripts/run-tests.sh"
+        env:
+          PG_VERSION: ${{ matrix.postgres }}
+      - name: Upload Postgres logs
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: postgres-server-${{ matrix.postgres }}-logs
+          path: |
+            /tmp/pg-out.log
+            /tmp/pg-error.log
+      - name: Upload to codecov
+        uses: codecov/codecov-action@v3
+        env:
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
+        if: ${{ env.codecov_token != '' && matrix.postgres == 15 }} # for now run only on once
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: codecov-lanterndb
+          fail_ci_if_error: true
+          files: /tmp/coverage.xml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,16 @@ endif()
 option(DEV "Developer mode: provide code formatting, get postgres source, etc." OFF)
 option(BUILD_WITH_USEARCH "Build with usearch as hnsw provider" ON)
 option(BUILD_LIBHNSW "Build libhnsw as hnsw provider" OFF)
+option(CODECOVERAGE "Enable code coverage for the build" OFF)
+
+if(CODECOVERAGE)
+  message(STATUS "Code coverage is enabled.")
+  # Note that --coverage is synonym for the necessary compiler and linker flags
+  # for the given compiler.  For example, with GCC, --coverage translates to
+  # -fprofile-arcs -ftest-coverage when compiling and -lgcov when linking
+  add_compile_options(--coverage -O0)
+  add_link_options(--coverage)
+endif(CODECOVERAGE)
 
 # options passed into lanterndb sourcecode
 # todo:: tests for copynodes=ON are broken
@@ -73,6 +83,7 @@ endforeach()
 if(APPLE)
   set(_link_flags "${_link_flags} -bundle_loader ${PG_BINARY}")
 endif()
+
 
 set_target_properties(
   lanterndb

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # LanternDB 🏮
 
-[![build](https://github.com/lanterndata/lanterndb/actions/workflows/build-and-test-linux.yaml/badge.svg?branch=main)](https://github.com/lanterndata/lanterndb/actions/workflows/build-and-test-linux.yaml)
+[![build](https://github.com/lanterndata/lanterndb/actions/workflows/build-linux.yaml/badge.svg?branch=main)](https://github.com/lanterndata/lanterndb/actions/workflows/build-linux.yaml)
+[![test](https://github.com/lanterndata/lanterndb/actions/workflows/test-linux.yaml/badge.svg?branch=main)](https://github.com/lanterndata/lanterndb/actions/workflows/test-linux.yaml)
 
 LanternDB is a relational and vector database, packaged as a Postgres extension.
 It provides a new index type for vector columns called `hnsw` which speeds up `ORDER BY` queries on the table.
 
 ## Quickstart
+
 Note: Currently LanternDB depends on [pgvector](https://github.com/pgvector/pgvector) for the `vector` data type. You'll need to manually install pgvector before moving to the next step.
 
 LanternDB builds and uses [usearch](https://github.com/unum-cloud/usearch) for its single-header state of the art HNSW implementation.
 
 To build and install LanternDB:
+
 ```bash
 git clone --recursive https://github.com/lanterndata/lanterndb.git
 cd lanterndb
@@ -25,10 +28,13 @@ make install
 To install on M1 macs, replace `cmake ..` from the above with `cmake -DUSEARCH_NO_MARCH_NATIVE=ON ..` to avoid building usearch with unsupported `march=native`
 
 ## Using LanternDB
+
 Run the following to enable lanterndb:
+
 ```sql
 CREATE EXTENSION lanterndb;
 ```
+
 Then, you can create a table with a vector column and populate it with data.
 
 ```sql
@@ -48,7 +54,9 @@ INSERT INTO small_world (id, vector) VALUES
 ('110', '[1,1,0]'),
 ('111', '[1,1,1]');
 ```
+
 Then, create an `hnsw` index on the table.
+
 ```sql
 -- create index with default parameters
 CREATE INDEX ON small_world USING hnsw (vector);
@@ -57,6 +65,7 @@ CREATE INDEX ON small_world USING hnsw (vector);
 ```
 
 Leverage the index in queries like:
+
 ```sql
 SELECT id, ROUND( (vector <-> '[0,0,0]')::numeric, 2) as dist
 FROM small_world
@@ -64,15 +73,18 @@ ORDER BY vector <-> '[0,0,0]' LIMIT 5;
 ```
 
 ### A note on index construction parameters
+
 The `M`, `ef`, and `efConstruction` parameters control the tradeoffs of the HNSW algorithm.
 In general, lower `M` and `efConstruction` speed up index creation at the cost of recall.
 Lower `M` and `ef` improve search speed and result in fewer shared buffer hits at the cost of recall.
 Tuning these parameters will require experimentation for your specific use case. An upcoming LanternDB release will include an optional auto-tuning index.
 
 ### A note on performnace
+
 LanternDB's `hnsw` enables search latency similar to pgvector's `ivfflat` and is faster than `ivfflat` under certain construction parameters. LanternDB enables higher search throughput on the same hardware since the HNSW algorithm requires fewer distance comparisons than the IVF algorithm, leading to less CPU usage per search.
 
 # Roadmap
+
 - [x] Postgres wal-backed hnsw index creation on existing tables with sane defaults
 - [x] Efficient index lookups, backed by usearch and postgres wal
 - [ ] `INSERT`s into the created index
@@ -87,4 +99,3 @@ LanternDB's `hnsw` enables search latency similar to pgvector's `ivfflat` and is
 - [ ] Add more distance functions
 - [ ] Add Product Quantization as another vector compression method
 - [ ] Implement a Vamana index introduced in [DiskANN](https://proceedings.neurips.cc/paper_files/paper/2019/file/09853c7fb1d3f8ee67a61b6bf4a7f8e6-Paper.pdf) to potentially reduce the number of buffers hit during an index scan.
-

--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -2,10 +2,16 @@
 
 get_cmake_flags(){
  # TODO:: remove after test
- echo "-DUSEARCH_NO_MARCH_NATIVE=ON"
+ flags="-DUSEARCH_NO_MARCH_NATIVE=ON"
  # if [[ $ARCH == *"arm"* ]]; then
  #   echo "-DUSEARCH_NO_MARCH_NATIVE=ON"
  # fi
+ if [ -n "$ENABLE_COVERAGE" ]
+ then
+   flags="$flags -DCMAKE_C_COMPILER=/usr/bin/gcc -DCODECOVERAGE=ON"
+ fi
+
+ echo $flags
 }
 
 export BRANCH=$BRANCH_NAME
@@ -34,7 +40,7 @@ echo "LANG=en_US.UTF-8" > /etc/locale.conf && \
 apt update -y && apt install locales -y && \
 locale-gen en_US.UTF-8 && \
 # Install required packages for build
-apt install lsb-core build-essential automake cmake wget git dpkg-dev wget -y && \
+apt install lsb-core build-essential automake cmake wget git dpkg-dev gcovr -y && \
 # Add postgresql apt repo
 export ARCH=$(dpkg-architecture -q DEB_BUILD_ARCH) && \
 sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
@@ -46,7 +52,7 @@ apt install postgresql-$PG_VERSION-pgvector -y
 # Fix pg_config (sometimes it points to wrong version)
 rm -f /usr/bin/pg_config && ln -s /usr/lib/postgresql/$PG_VERSION/bin/pg_config /usr/bin/pg_config
 
-if [ -z ${USE_SOURCE+x} ]; then
+if [ -z ${USE_SOURCE} ]; then
   # Clone from git
   cd /tmp && git clone --recursive https://github.com/lanterndata/lanterndb.git -b $BRANCH
 else 
@@ -57,17 +63,19 @@ fi
 cd /tmp/lanterndb && mkdir build && cd build && \
 # Run cmake
 sh -c "cmake $(get_cmake_flags) .." && \
-make install && \
-# Bundle debian packages && \
-cpack &&
- 
-# Print package name to github output
-export EXT_VERSION=$(cmake --system-information | awk -F= '$1~/CMAKE_PROJECT_VERSION:STATIC/{print$2}') && \
-export PACKAGE_NAME=lanterndb-${EXT_VERSION}-postgres-${PG_VERSION}-${ARCH}.deb && \
+make install
 
-echo "package_version=$EXT_VERSION" >> "$GITHUB_OUTPUT" && \
-echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT" && \
-echo "package_path=$(pwd)/$(ls *.deb | tr -d '\n')" >> "$GITHUB_OUTPUT"
+if [ -n "$BUILD_PACKAGES" ]; then
+  # Bundle debian packages
+  cpack &&
+  # Print package name to github output
+  export EXT_VERSION=$(cmake --system-information | awk -F= '$1~/CMAKE_PROJECT_VERSION:STATIC/{print$2}') && \
+  export PACKAGE_NAME=lanterndb-${EXT_VERSION}-postgres-${PG_VERSION}-${ARCH}.deb && \
+
+  echo "package_version=$EXT_VERSION" >> "$GITHUB_OUTPUT" && \
+  echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT" && \
+  echo "package_path=$(pwd)/$(ls *.deb | tr -d '\n')" >> "$GITHUB_OUTPUT"
+fi
 
 # Chown to postgres for running tests
 chown -R postgres:postgres /tmp/lanterndb

--- a/ci/scripts/run-tests.sh
+++ b/ci/scripts/run-tests.sh
@@ -21,10 +21,17 @@ then
   export PG_VERSION=15
 fi
 
+if [ -z "$GITHUB_OUTPUT" ]
+then
+  export GITHUB_OUTPUT=/dev/null
+fi
+
 export PGDATA=/etc/postgresql/$PG_VERSION/main/
 # Set port
 echo "port = 5432" >> $PGDATA/postgresql.conf
 # Run postgres database
-POSTGRES_HOST_AUTH_METHOD=trust /usr/lib/postgresql/$PG_VERSION/bin/postgres &>/dev/null &
+GCOV_PREFIX=$WORKDIR/build/CMakeFiles/lanterndb.dir/ GCOV_PREFIX_STRIP=5 POSTGRES_HOST_AUTH_METHOD=trust /usr/lib/postgresql/$PG_VERSION/bin/postgres 1>/tmp/pg-out.log 2>/tmp/pg-error.log &
 # Wait for start and run tests
-wait_for_pg && cd $WORKDIR/build && make test
+wait_for_pg && cd $WORKDIR/build && make test && \
+killall postgres && \
+gcovr -r $WORKDIR/src/ --object-directory $WORKDIR/build/ --xml /tmp/coverage.xml


### PR DESCRIPTION
## Description
- Separated workflows for build and test actions, so we can have 2 different badges in our README file.
- Now the test action will output the postgres server logs, so we can download and analyze it.
- Ability to manually trigger tests with debug mode which will give ssh connection string to runner, so we can manually connect and do live debugging.
- Added code coverage with `gcov` and action to upload coverage results to `codecov`

We need to add repo in [Codecov](https://app.codecov.io/) and add `CODECOV_TOKEN` in Github Actions secrets

Here's the screenshot of how the test results are being shown in the dashboard
<img width="1444" alt="image" src="https://github.com/lanterndata/lanterndb/assets/17221195/ebf0f01d-fe0c-47bd-8f4c-a50b84a381b0">

We can also add coverage report badge to README file.