### PR TITLE
create index with dynamically allocated blockmaps

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,8 @@ COPY . .
 # Set Locale
 RUN apt update && apt-mark hold locales && \
 # Install required packages for build
-apt install -y --no-install-recommends build-essential cmake postgresql-server-dev-15 gdb
+apt install -y --no-install-recommends build-essential cmake postgresql-server-dev-15 gdb wget postgres-15-pgvector python3-pip sudo && \
+    pip install libtmux --break-system-packages
 
 # Build lanterndb
 RUN mkdir build && cd build && \

--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -15,8 +15,11 @@
 #include "usearch.h"
 #include "utils/relcache.h"
 
-static inline void fill_blockno_mapping(BlockNumber *wal_retriever_block_numbers);
-static Cache       wal_retriever_block_numbers_cache;
+static Cache  wal_retriever_block_numbers_cache;
+static uint32 g_blockmap_groups = 0;
+static uint32 g_blockmap_group_indexes[ HNSW_MAX_BLOCKMAP_GROUPS ];
+static uint32 g_number_of_blocks = 1;
+static uint32 g_num_vectors = 0;
 
 int UsearchNodeBytes(usearch_metadata_t *metadata, int vector_bytes, int level)
 {
@@ -47,39 +50,84 @@ static char *extract_node(char               *data,
     return tape;
 }
 
-void StoreExternalIndex(Relation        index,
+int CreateBlockMapGroup(
+                        HnswIndexHeaderPage* hdr,
+                        Relation index,
+                        ForkNumber forkNum,
+                        int first_node_index,
+                        int group_num)
+{
+    // Create empty blockmap pages for the group
+    const int number_of_blockmaps_in_group = 1 << group_num;
+    // elog(INFO, "davkhech number_of_blockmaps_in_group %d num_added_vectors %d", number_of_blockmaps_in_group, num_added_vectors);
+    for (int blockmap_id = 0; blockmap_id < number_of_blockmaps_in_group; ++blockmap_id) {
+        Buffer buf = ReadBufferExtended(index, forkNum, P_NEW, RBM_NORMAL, NULL);
+        LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
+
+        GenericXLogState *state = GenericXLogStart(index);
+        Page page = GenericXLogRegisterBuffer(state, buf, GENERIC_XLOG_FULL_IMAGE);
+        PageInit(page, BufferGetPageSize(buf), sizeof(HnswIndexPageSpecialBlock));
+
+        HnswIndexPageSpecialBlock *special = (HnswIndexPageSpecialBlock *)PageGetSpecialPointer(page);
+        special->firstId = first_node_index + blockmap_id * HNSW_BLOCKMAP_BLOCKS_PER_PAGE;
+        special->nextblockno = InvalidBlockNumber;
+
+        HnswBlockmapPage *blockmap = palloc0(BLCKSZ);
+        blockmap->first_id = first_node_index + blockmap_id * HNSW_BLOCKMAP_BLOCKS_PER_PAGE;
+
+        if(PageAddItem(page, (Item)blockmap, sizeof(HnswBlockmapPage), InvalidOffsetNumber, false, false)
+           == InvalidOffsetNumber) {
+            // we always add a single Blockmap page per Index page which has a fixed size that
+            // always fits in postgres wal page. So this should never happen
+            // (Assumes 8k BLKSZ. we can make HnswBlockmapPage size configurable by BLCKSZ)
+            elog(ERROR, "could not add blockmap to page");
+        }
+
+        special->lastId = first_node_index + (blockmap_id + 1) * HNSW_BLOCKMAP_BLOCKS_PER_PAGE - 1;
+        special->nextblockno = BufferGetBlockNumber(buf) + 1;
+        if (blockmap_id == 0) {
+            if (hdr == NULL) {
+                g_blockmap_group_indexes[group_num] = BufferGetBlockNumber(buf);
+            } else {
+                hdr->blockmap_page_groups = group_num;
+                hdr->blockmap_page_group_index[group_num] = BufferGetBlockNumber(buf);
+            }
+        }
+        // elog(INFO, "davkhech page block special %d %d group %d index %d", special->lastId, special->nextblockno, g_blockmap_groups, g_blockmap_group_indexs[g_blockmap_groups]);
+        MarkBufferDirty(buf);
+        GenericXLogFinish(state);
+        UnlockReleaseBuffer(buf);
+    }
+
+    return number_of_blockmaps_in_group;
+}
+
+void StoreExternalIndexBlockMapGroup(
+                        Relation        index,
                         usearch_index_t external_index,
                         ForkNumber      forkNum,
                         char           *data,
+                        int            *progress,
                         size_t          external_index_size,
                         int             dimension,
-                        size_t          num_added_vectors)
+                        int             first_node_index,
+                        size_t          num_added_vectors) 
 {
+    const int number_of_blockmaps_in_group = CreateBlockMapGroup(NULL, index, forkNum, first_node_index, g_blockmap_groups);
+
+    // Now add nodes to data pages
     char  *node = 0;
     int    node_size = 0;
     int    node_level = 0;
-    int    progress = 64;  // usearch header size
     uint32 predicted_next_block = InvalidBlockNumber;
     uint32 last_block = -1;
-    uint32 block = 1;
-    uint32 blockno_index_start = -1;
-
-    if(num_added_vectors >= HNSW_MAX_INDEXED_VECTORS) {
-        elog(ERROR, "too many vectors to store in hnsw index. Current limit: %d", HNSW_MAX_INDEXED_VECTORS);
-    }
-
-    BlockNumber    *wal_retriever_block_numbers = NULL;
+    BlockNumber *l_wal_retriever_block_numbers = palloc0(sizeof(BlockNumber) * number_of_blockmaps_in_group * HNSW_BLOCKMAP_BLOCKS_PER_PAGE);
+    
     HnswIndexTuple *bufferpage = palloc(BLCKSZ);
-
     usearch_metadata_t metadata = usearch_metadata(external_index, NULL);
 
-    // header page is created twice. it is always at block=0 so the second time just overrides it
-    // it is added here to make sure a data block does not get to block=0.
-    // after somem sleep I will prob find a better way to do this
-    CreateHeaderPage(index, data, forkNum, dimension, num_added_vectors, -1, -1, false);
-
     /* Add all the vectors to the WAL */
-    for(int node_id = 0; node_id < num_added_vectors;) {
+    for(int node_id = first_node_index; node_id < first_node_index + num_added_vectors;) {
         // 1. create HnswIndexTuple
 
         // 2. fill header and special
@@ -88,17 +136,11 @@ void StoreExternalIndex(Relation        index,
         //     3a. add node to page
 
         // 4. commit buffer
-
-        Buffer                     buf;
-        Page                       page;
-        GenericXLogState          *state;
-        HnswIndexPageSpecialBlock *special;
-
-        buf = ReadBufferExtended(index, forkNum, P_NEW, RBM_NORMAL, NULL);
+        Buffer buf = ReadBufferExtended(index, forkNum, P_NEW, RBM_NORMAL, NULL);
         LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
 
-        state = GenericXLogStart(index);
-        page = GenericXLogRegisterBuffer(state, buf, GENERIC_XLOG_FULL_IMAGE);
+        GenericXLogState *state = GenericXLogStart(index);
+        Page page = GenericXLogRegisterBuffer(state, buf, GENERIC_XLOG_FULL_IMAGE);
         PageInit(page, BufferGetPageSize(buf), sizeof(HnswIndexPageSpecialBlock));
 
         if(predicted_next_block != InvalidBlockNumber) {
@@ -112,19 +154,21 @@ void StoreExternalIndex(Relation        index,
             }
         }
 
-        special = (HnswIndexPageSpecialBlock *)PageGetSpecialPointer(page);
+        HnswIndexPageSpecialBlock *special = (HnswIndexPageSpecialBlock *)PageGetSpecialPointer(page);
         special->firstId = node_id;
         special->nextblockno = InvalidBlockNumber;
 
+        // elog(INFO, "davkhech start adding nodes %d %d", node_id, BufferGetBlockNumber(buf));
         // note: even if the condition is true, nodepage may be too large
         // as the condition does not take into account the flexible array component
         while(PageGetFreeSpace(page) > sizeof(HnswIndexTuple) + dimension * sizeof(float)) {
-            if(node_id >= num_added_vectors) break;
+            if(node_id >= first_node_index + num_added_vectors) break;
+            // elog(INFO, "davkhech start adding nodes %d to page %d", node_id, BufferGetBlockNumber(buf));
             memset(bufferpage, 0, BLCKSZ);
             /************* extract node from usearch index************/
 
             node = extract_node(data,
-                                progress,
+                                *progress,
                                 dimension,
                                 &metadata,
                                 /*->>output*/ &node_size,
@@ -155,107 +199,87 @@ void StoreExternalIndex(Relation        index,
                 break;
             }
 
+            // elog(INFO, "davkhech end adding nodes %d to page %d", node_id, BufferGetBlockNumber(buf));
             // we successfully recorded the node. move to the next one
-            progress += node_size;
+            *(l_wal_retriever_block_numbers + node_id - first_node_index) = BufferGetBlockNumber(buf);
+            *progress += node_size;
             node_id++;
         }
-        if(node_id < num_added_vectors) {
+        if(node_id < num_added_vectors + first_node_index) {
             predicted_next_block = BufferGetBlockNumber(buf) + 1;
         } else {
-            last_block = predicted_next_block;
+            last_block = BufferGetBlockNumber(buf);
             predicted_next_block = InvalidBlockNumber;
         }
         special->lastId = node_id - 1;
         special->nextblockno = predicted_next_block;
+        // elog(INFO, "davkhech data special %d %d %d %d", special->lastId, special->nextblockno, g_blockmap_groups, g_blockmap_group_indexs[g_blockmap_groups]);
         MarkBufferDirty(buf);
         GenericXLogFinish(state);
         UnlockReleaseBuffer(buf);
     }
+    CreateHeaderPage(index, data, forkNum, dimension, 0, last_block, last_block, true);
+    // elog(WARNING, "davkhech now updating blockmap");
 
-    HnswBlockmapPage *blockmap = palloc0(BLCKSZ);
-    // I do update header page yet another time here to update num_vectors and the global
-    // HEADER_FOR_EXTERNAL_RETRIEVER which is used by fill_blockno_mapping
-    CreateHeaderPage(index, data, forkNum, dimension, num_added_vectors, blockno_index_start, last_block, true);
-    wal_retriever_block_numbers = palloc0(sizeof(BlockNumber) * num_added_vectors);
-    if(wal_retriever_block_numbers == NULL) elog(ERROR, "could not allocate wal_retriever_block_numbers");
-    INDEX_RELATION_FOR_RETRIEVER = index;
-    fill_blockno_mapping(wal_retriever_block_numbers);
-
-    /* Create blockmap for <=2 memory access retreival of any node*/
-    for(int node_id = 0; node_id < HNSW_MAX_INDEXED_VECTORS; node_id += HNSW_BLOCKMAP_BLOCKS_PER_PAGE) {
-        Buffer                     buf;
-        Page                       page;
-        GenericXLogState          *state;
-        HnswIndexPageSpecialBlock *special;
-
-        buf = ReadBufferExtended(index, forkNum, P_NEW, RBM_NORMAL, NULL);
-        if(blockno_index_start == -1) {
-            blockno_index_start = BufferGetBlockNumber(buf);
-        }
+    // Update blockmap pages with correct associations
+    for (int blockmap_id = 0; blockmap_id < number_of_blockmaps_in_group; ++blockmap_id) {
+        const BlockNumber blockmapno = blockmap_id + g_blockmap_group_indexes[g_blockmap_groups];
+        Buffer buf = ReadBufferExtended(index, MAIN_FORKNUM, blockmapno, RBM_NORMAL, NULL);
         LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
 
-        state = GenericXLogStart(index);
-        page = GenericXLogRegisterBuffer(state, buf, GENERIC_XLOG_FULL_IMAGE);
-        PageInit(page, BufferGetPageSize(buf), sizeof(HnswIndexPageSpecialBlock));
+        GenericXLogState *state = GenericXLogStart(index);
+        Page page = GenericXLogRegisterBuffer(state, buf, GENERIC_XLOG_FULL_IMAGE);
 
-#if 0
-        /* I was trying to figure out how postgres allocates blocks
-         * It seems it always gives n+1 block after block n and have not been
-         * able to find a counterexample
-         */
-        if(predicted_next_block != InvalidBlockNumber) {
-            if(predicted_next_block != BufferGetBlockNumber(buf)) {
-                elog(ERROR,
-                     "my block number hypothesis failed. "
-                     "predicted block number %d does not match "
-                     "actual %d",
-                     predicted_next_block,
-                     BufferGetBlockNumber(buf));
-            }
-        }
-#endif
-
-        special = (HnswIndexPageSpecialBlock *)PageGetSpecialPointer(page);
-        special->firstId = node_id;
-        special->nextblockno = InvalidBlockNumber;
-
-        memset(blockmap, 0, BLCKSZ);
-        blockmap->first_id = node_id;
-
-        // for already inserted nodes, we populate corresponding to blockmap pages
-        // Otherwise, we only populate expected first node_id and leave the rest for INSERTS
-        if(node_id < num_added_vectors) {
-            memcpy(blockmap->blocknos,
-                   wal_retriever_block_numbers + node_id,
-                   sizeof(BlockNumber) * HNSW_BLOCKMAP_BLOCKS_PER_PAGE);
-        }
-        if(PageAddItem(page, (Item)blockmap, sizeof(HnswBlockmapPage), InvalidOffsetNumber, false, false)
-           == InvalidOffsetNumber) {
-            // we always add a single Blockmap page per Index page which has a fixed size that
-            // always fits in postgres wal page. So this should never happen
-            // (Assumes 8k BLKSZ. we can make HnswBlockmapPage size configurable by BLCKSZ)
-            elog(ERROR, "could not add blockmap to page");
-        }
-
-        if(node_id < num_added_vectors) {
-            predicted_next_block = BufferGetBlockNumber(buf) + 1;
-        } else {
-            last_block = predicted_next_block;
-            predicted_next_block = InvalidBlockNumber;
-        }
-        special->lastId = node_id - 1;
-        special->nextblockno = predicted_next_block;
+        HnswBlockmapPage *blockmap = (HnswBlockmapPage *)PageGetItem(page, PageGetItemId(page, FirstOffsetNumber));
+        memcpy(blockmap->blocknos, l_wal_retriever_block_numbers + blockmap_id * HNSW_BLOCKMAP_BLOCKS_PER_PAGE, sizeof(BlockNumber) * HNSW_BLOCKMAP_BLOCKS_PER_PAGE);
         MarkBufferDirty(buf);
         GenericXLogFinish(state);
         UnlockReleaseBuffer(buf);
     }
+    // elog(INFO, "davkhech finished with group");
+}
 
-    pfree(wal_retriever_block_numbers);
-    wal_retriever_block_numbers = NULL;
-    pfree(blockmap);
-    CreateHeaderPage(index, data, forkNum, dimension, num_added_vectors, blockno_index_start, last_block, true);
+void StoreExternalIndex(Relation        index,
+                        usearch_index_t external_index,
+                        ForkNumber      forkNum,
+                        char           *data,
+                        size_t          external_index_size,
+                        int             dimension,
+                        size_t          num_added_vectors)
+{
+    int progress = 64;  // usearch header size
+    if(num_added_vectors >= HNSW_MAX_INDEXED_VECTORS) {
+        elog(ERROR, "too many vectors to store in hnsw index. Current limit: %d", HNSW_MAX_INDEXED_VECTORS);
+    }
 
-    pfree(bufferpage);
+    // header page is created twice. it is always at block=0 so the second time just overrides it
+    // it is added here to make sure a data block does not get to block=0.
+    // after somem sleep I will prob find a better way to do this
+    CreateHeaderPage(index, data, forkNum, dimension, num_added_vectors, -1, -1, false);
+
+    uint32 number_of_index_pages = num_added_vectors / HNSW_BLOCKMAP_BLOCKS_PER_PAGE + 1;
+    int group_node_first_index = 0;
+    int num_added_vectors_remaining = (int)num_added_vectors;
+    int batch_size = HNSW_BLOCKMAP_BLOCKS_PER_PAGE;
+    while (num_added_vectors_remaining > 0) {
+        // elog(INFO, "davkhech adding group num_added_vectors %d batch_size %d num_added_vectors_remaining %d group_node_first_index %d", num_added_vectors, batch_size, num_added_vectors_remaining, group_node_first_index);
+        StoreExternalIndexBlockMapGroup(
+            index,
+            external_index,
+            forkNum,
+            data,
+            &progress,
+            external_index_size,
+            dimension,
+            group_node_first_index,
+            Min(num_added_vectors_remaining, batch_size)
+        );
+        num_added_vectors_remaining -= batch_size;
+        group_node_first_index += batch_size;
+        batch_size = batch_size * 2;
+        g_blockmap_groups ++;
+        // elog(INFO, "davkhech index block map group added: num_added_vectors_remaining %d, group_node_first_index %d, batch_size %d, g_blockmap_groups %d", num_added_vectors_remaining, group_node_first_index, batch_size, g_blockmap_groups);
+    }
 }
 
 void CreateHeaderPage(Relation   index,
@@ -263,7 +287,7 @@ void CreateHeaderPage(Relation   index,
                       ForkNumber forkNum,
                       int        vector_dim,
                       int        num_vectors,
-                      uint32     blockno_index_start,
+                      BlockNumber last_data_block,
                       uint32     num_blocks,
                       bool       update)
 {
@@ -271,12 +295,10 @@ void CreateHeaderPage(Relation   index,
     Page                 page;
     GenericXLogState    *state;
     HnswIndexHeaderPage *headerp;
-    BlockNumber          headerblockno = 0;
+    BlockNumber          headerblockno = P_NEW;
 
     if(update) {
         headerblockno = 0;
-    } else {
-        headerblockno = P_NEW;
     }
     buf = ReadBufferExtended(index, forkNum, headerblockno, RBM_NORMAL, NULL);
     LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
@@ -289,19 +311,21 @@ void CreateHeaderPage(Relation   index,
     headerp->magicNumber = LDB_WAL_MAGIC_NUMBER;
     headerp->version = LDB_WAL_VERSION_NUMBER;
     headerp->vector_dim = vector_dim;
-    headerp->num_vectors = num_vectors;
-    headerp->first_data_block = InvalidBlockNumber;
-    headerp->last_data_block = InvalidBlockNumber;
-    if(blockno_index_start >= headerblockno + 2) {
-        // headerblockno+1 is a data page
-        headerp->first_data_block = headerblockno + 1;
-        headerp->last_data_block = blockno_index_start - 1;
-    } else {
-        elog(WARNING, "creating index on empty table");
-    }
-    headerp->last_data_block = blockno_index_start - 1;
-    headerp->blockno_index_start = blockno_index_start;
+
+    headerp->last_data_block = last_data_block;
     headerp->num_blocks = num_blocks;
+    if (!update) {
+        g_num_vectors = num_vectors;
+        headerp->num_vectors = num_vectors;
+        headerp->blockmap_page_groups = 0;
+        memset(headerp->blockmap_page_group_index, 0, HNSW_MAX_BLOCKMAP_GROUPS);
+        g_blockmap_groups = 0;
+        memset(g_blockmap_group_indexes, 0, HNSW_MAX_BLOCKMAP_GROUPS);
+    } else {
+        headerp->num_vectors = g_num_vectors;
+        headerp->blockmap_page_groups = g_blockmap_groups;
+        memcpy(headerp->blockmap_page_group_index, g_blockmap_group_indexes, sizeof(g_blockmap_group_indexes));
+    }
     memcpy(headerp->usearch_header, usearchHeader64, 64);
     ((PageHeader)page)->pd_lower = ((char *)headerp + sizeof(HnswIndexHeaderPage)) - (char *)page;
 
@@ -405,6 +429,7 @@ HnswIndexTuple *PrepareIndexTuple(Relation             index_rel,
                                   Page (*extra_dirtied_page)[ LDB_HNSW_INSERT_MAX_EXTRA_DIRTIED_BUFS ],
                                   int *extra_dirtied_size)
 {
+    // elog(INFO, "davkhech trying insert %d", new_tuple_id);
     // if any data blocks exist, the last one's buffer will be read into this
     Buffer last_dblock = InvalidBuffer;
     // if a new data buffer is created for the inserted vector, it will be stored here
@@ -433,7 +458,6 @@ HnswIndexTuple *PrepareIndexTuple(Relation             index_rel,
      *  (create new page if necessary) ***/
 
     if(hdr->last_data_block == InvalidBlockNumber) {
-        assert(hdr->first_data_block == InvalidBlockNumber);
         elog(ERROR, "inserting into an empty table not supported");
         // index is created on the empty table.
         // allocate the first page here
@@ -462,9 +486,12 @@ HnswIndexTuple *PrepareIndexTuple(Relation             index_rel,
             (*extra_dirtied_page)[ (*extra_dirtied_size) - 1 ] = page;
         }
 
-        if(PageGetFreeSpace(page) > sizeof(HnswIndexTuple) + alloced_tuple->size) {
+        const blockmaps_are_enough = new_tuple_id / HNSW_BLOCKMAP_BLOCKS_PER_PAGE + 1 < (1 << (hdr->blockmap_page_groups + 1));
+        // elog(INFO, "davkhech %d", blockmaps_are_enough);
+        if(PageGetFreeSpace(page) > sizeof(HnswIndexTuple) + alloced_tuple->size && blockmaps_are_enough) {
             // there is enough space in the last page to fit the new vector
             // so we just append it to the page
+            // elog(INFO, "davkhech can put in page %d", new_tuple_id);
             elog(DEBUG5, "InsertBranching: we adding element to existing page");
             new_tup_at = HnswIndexPageAddVector(page, alloced_tuple, alloced_tuple->size);
             new_vector_blockno = BufferGetBlockNumber(last_dblock);
@@ -473,6 +500,7 @@ HnswIndexTuple *PrepareIndexTuple(Relation             index_rel,
             MarkBufferDirty(last_dblock);
         } else {
             elog(DEBUG5, "InsertBranching: creating new data bage to add an element to");
+            // elog(INFO, "davkhech need to put in new page %d", new_tuple_id);
             // 1. create and read a new block
             // 2. store the new block blockno in the last block special
             // 2.5 update index header to point to the new last page
@@ -483,6 +511,15 @@ HnswIndexTuple *PrepareIndexTuple(Relation             index_rel,
             // todo:: I think if for some reason insertion fails after this point, the new block will stick
             // around. So, perhaps we should do what we did with blockmap and have a separate wal record for new
             // page creation.
+
+            // check the count of blockmaps, see if there's place to add the block id, if yes add, if no create a new group
+            // check if already existing blockmaps are not enough
+            // new_tuple_id / HNSW_BLOCKMAP_BLOCKS_PER_PAGE + 1 is kth blockmap
+            // we check if k is more than already created 2^groups
+            if (new_tuple_id / HNSW_BLOCKMAP_BLOCKS_PER_PAGE + 1 >= (1 << (hdr->blockmap_page_groups + 1))) {
+                CreateBlockMapGroup(hdr, index_rel, MAIN_FORKNUM, new_tuple_id, hdr->blockmap_page_groups + 1);
+            }
+
             new_dblock = ReadBufferExtended(index_rel, MAIN_FORKNUM, P_NEW, RBM_NORMAL, NULL);
             LockBuffer(new_dblock, BUFFER_LOCK_EXCLUSIVE);
             new_vector_blockno = BufferGetBlockNumber(new_dblock);
@@ -521,7 +558,7 @@ HnswIndexTuple *PrepareIndexTuple(Relation             index_rel,
     /*** Update pagemap with the information of the added page ***/
     {
         int               id_offset = (new_tuple_id / HNSW_BLOCKMAP_BLOCKS_PER_PAGE) * HNSW_BLOCKMAP_BLOCKS_PER_PAGE;
-        BlockNumber       blockmapno = hdr->blockno_index_start + id_offset / HNSW_BLOCKMAP_BLOCKS_PER_PAGE;
+        BlockNumber       blockmapno = getBlockMapPageBlockNumber(hdr, new_tuple_id);
         Page              blockmap_page;
         HnswBlockmapPage *blockmap;
         int               max_offset;
@@ -591,13 +628,23 @@ void ldb_wal_retriever_area_free()
 #endif
 }
 
+BlockNumber getBlockMapPageBlockNumber(HnswIndexHeaderPage* hdr, int id) {
+    assert(id >= 0);
+    // Trust me, I'm an engineer!
+    id = id / HNSW_BLOCKMAP_BLOCKS_PER_PAGE + 1;
+    int k;
+    for (k = 0; id >= (1 << k); ++k) {}
+    return hdr->blockmap_page_group_index[k - 1] + (id - (1 << (k - 1)));
+}
+
 static inline void *wal_index_node_retriever_exact(int id)
 {
+    // elog(WARNING, "davkhech retreiver called %d", id);
     HnswBlockmapPage *blockmap_page;
     // fix blockmap size to X pages -> X * 8k overhead -> can have max table size of 2000 * X
     // fix blockmap size to 20000 pages -> 160 MB overhead -> can have max table size of 40M rows
     // 40M vectors of 128 dims -> 40 * 128 * 4 = 163840 Mbytes -> 163 GB... will not fly
-    BlockNumber     blockmapno = HEADER_FOR_EXTERNAL_RETRIEVER.blockno_index_start + id / HNSW_BLOCKMAP_BLOCKS_PER_PAGE;
+    BlockNumber     blockmapno = getBlockMapPageBlockNumber(&HEADER_FOR_EXTERNAL_RETRIEVER, id);
     BlockNumber     blockno;
     Buffer          buf;
     Page            page;
@@ -722,8 +769,9 @@ static inline void *wal_index_node_retriever_exact(int id)
 
 void *ldb_wal_index_node_retriever_mut(int id)
 {
+    // elog(WARNING, "davkhech retreiver mut called %d", id);
     HnswBlockmapPage *blockmap_page;
-    BlockNumber     blockmapno = HEADER_FOR_EXTERNAL_RETRIEVER.blockno_index_start + id / HNSW_BLOCKMAP_BLOCKS_PER_PAGE;
+    BlockNumber     blockmapno = getBlockMapPageBlockNumber(&HEADER_FOR_EXTERNAL_RETRIEVER, id);
     BlockNumber     blockno;
     Buffer          buf;
     Page            page;
@@ -812,38 +860,4 @@ void *ldb_wal_index_node_retriever(int id)
     return wal_index_node_retriever_exact(id);
     // return wal_index_node_retriever_sequential(id);
     // return wal_index_node_retriever_binary(id);
-}
-
-static inline void fill_blockno_mapping(BlockNumber *wal_retriever_block_numbers)
-{
-    BlockNumber                blockno = 1;
-    Buffer                     buf;
-    Page                       page;
-    HnswIndexPageSpecialBlock *special_block;
-    HnswIndexTuple            *nodepage;
-    OffsetNumber               offset, max_offset;
-
-    while(BlockNumberIsValid(blockno)) {
-        buf = ReadBufferExtended(INDEX_RELATION_FOR_RETRIEVER, MAIN_FORKNUM, blockno, RBM_NORMAL, NULL);
-        LockBuffer(buf, BUFFER_LOCK_SHARE);
-        page = BufferGetPage(buf);
-        max_offset = PageGetMaxOffsetNumber(page);
-        // todo:: do I set special_block->nextblockno of the last block correctly?
-
-        for(offset = FirstOffsetNumber; offset <= max_offset; offset = OffsetNumberNext(offset)) {
-            nodepage = (HnswIndexTuple *)PageGetItem(page, PageGetItemId(page, offset));
-            if(wal_retriever_block_numbers[ nodepage->id ] != 0) {
-                elog(ERROR,
-                     "ldb_wal_retriever_area_init: duplicate id %d at offset %d. prev. blockno: %d, new blockno: %d",
-                     nodepage->id,
-                     offset,
-                     wal_retriever_block_numbers[ nodepage->id ],
-                     blockno);
-            }
-            wal_retriever_block_numbers[ nodepage->id ] = blockno;
-        }
-        special_block = (HnswIndexPageSpecialBlock *)PageGetSpecialPointer(page);
-        blockno = special_block->nextblockno;
-        UnlockReleaseBuffer(buf);
-    }
 }

--- a/src/hnsw/external_index.h
+++ b/src/hnsw/external_index.h
@@ -17,6 +17,9 @@
 // used for code clarity when modifying WAL entries
 #define LDB_GENERIC_XLOG_DELTA_IMAGE 0
 
+// with so many blockmap groups we can store up to 2^32-1 vectors
+#define HNSW_MAX_BLOCKMAP_GROUPS 32
+
 // this should be as large as possible to cache more stuff
 // while still fitting on the first page
 #define NODE_STORAGE_NUM_COARSE 10
@@ -29,7 +32,6 @@ typedef struct HnswIndexHeaderPage
     // todo:: switch these to BlockNumber for documentation
     // first data block is needed because in case of creating an index on empty table it no longer
     // is headeblockno + 1
-    uint32 first_data_block;
     uint32 last_data_block;
     uint32 blockno_index_start;
     //todo:: get rid of this
@@ -37,6 +39,9 @@ typedef struct HnswIndexHeaderPage
     char   usearch_header[ 64 ];
     uint32 coarse_ids[ NODE_STORAGE_NUM_COARSE ];
     uint32 coarse_block[ NODE_STORAGE_NUM_COARSE ];
+
+    uint32 blockmap_page_groups;
+    uint32 blockmap_page_group_index[ HNSW_MAX_BLOCKMAP_GROUPS ];
 } HnswIndexHeaderPage;
 
 typedef struct HnswIndexPageSpecialBlock
@@ -122,5 +127,7 @@ HnswIndexTuple *PrepareIndexTuple(Relation             index_rel,
 
 void *ldb_wal_index_node_retriever(int id);
 void *ldb_wal_index_node_retriever_mut(int id);
+
+BlockNumber getBlockMapPageBlockNumber(HnswIndexHeaderPage* hdr, int id);
 
 #endif  // LDB_HNSW_EXTERNAL_INDEX_H

--- a/src/hnsw/insert.c
+++ b/src/hnsw/insert.c
@@ -106,7 +106,6 @@ bool ldb_aminsert(Relation         index,
         }
         assert(!error);
         INDEX_RELATION_FOR_RETRIEVER = index;
-        HEADER_FOR_EXTERNAL_RETRIEVER = *hdr;
         EXTRA_DIRTIED = &extra_dirtied[ 0 ];
         EXTRA_DIRTIED_PAGE = &extra_dirtied_page[ 0 ];
         EXTRA_DIRTIED_SIZE = 0;
@@ -156,6 +155,8 @@ bool ldb_aminsert(Relation         index,
     // header page MUST be under WAL since PrepareIndexTuple will update it
     hdr_page = GenericXLogRegisterBuffer(state, hdr_buf, LDB_GENERIC_XLOG_DELTA_IMAGE);
     hdr = (HnswIndexHeaderPage *)PageGetContents(hdr_page);
+
+    HEADER_FOR_EXTERNAL_RETRIEVER = *hdr;
 
     assert(hdr->magicNumber == LDB_WAL_MAGIC_NUMBER);
     elog(DEBUG5, "Insert: at start num vectors is %d", hdr->num_vectors);

--- a/test/expected/debug_helpers.out
+++ b/test/expected/debug_helpers.out
@@ -29,9 +29,9 @@ psql:test/sql/debug_helpers.sql:8: INFO:  inserted 8 elements
 psql:test/sql/debug_helpers.sql:8: INFO:  done saving 8 vectors
 CREATE INDEX
 SELECT * FROM ldb_get_indexes('small_world');
-       indexname        |  size  |                                   indexdef                                    
-------------------------+--------+-------------------------------------------------------------------------------
- small_world_vector_idx | 176 kB | CREATE INDEX small_world_vector_idx ON public.small_world USING hnsw (vector)
+       indexname        | size  |                                   indexdef                                    
+------------------------+-------+-------------------------------------------------------------------------------
+ small_world_vector_idx | 24 kB | CREATE INDEX small_world_vector_idx ON public.small_world USING hnsw (vector)
 (1 row)
 
 SHOW hnsw.init_k;

--- a/test/expected/hnsw.out
+++ b/test/expected/hnsw.out
@@ -54,9 +54,9 @@ psql:test/sql/hnsw.sql:43: INFO:  inserted 8 elements
 psql:test/sql/hnsw.sql:43: INFO:  done saving 8 vectors
 CREATE INDEX
 SELECT * FROM ldb_get_indexes('small_world');
-       indexname        |  size  |                                   indexdef                                    
-------------------------+--------+-------------------------------------------------------------------------------
- small_world_vector_idx | 176 kB | CREATE INDEX small_world_vector_idx ON public.small_world USING hnsw (vector)
+       indexname        | size  |                                   indexdef                                    
+------------------------+-------+-------------------------------------------------------------------------------
+ small_world_vector_idx | 24 kB | CREATE INDEX small_world_vector_idx ON public.small_world USING hnsw (vector)
 (1 row)
 
 SELECT * FROM (
@@ -111,9 +111,9 @@ psql:test/sql/hnsw.sql:59: INFO:  inserted 8 elements
 psql:test/sql/hnsw.sql:59: INFO:  done saving 8 vectors
 CREATE INDEX
 SELECT * FROM ldb_get_indexes('small_world');
-       indexname        |  size  |                                                         indexdef                                                          
-------------------------+--------+---------------------------------------------------------------------------------------------------------------------------
- small_world_vector_idx | 176 kB | CREATE INDEX small_world_vector_idx ON public.small_world USING hnsw (vector) WITH (m='2', ef='11', ef_construction='12')
+       indexname        | size  |                                                         indexdef                                                          
+------------------------+-------+---------------------------------------------------------------------------------------------------------------------------
+ small_world_vector_idx | 24 kB | CREATE INDEX small_world_vector_idx ON public.small_world USING hnsw (vector) WITH (m='2', ef='11', ef_construction='12')
 (1 row)
 
 SELECT ROUND( (vector <-> '[0,0,0]')::numeric, 2) as dist
@@ -187,9 +187,9 @@ psql:test/sql/hnsw.sql:85: INFO:  inserted 8 elements
 psql:test/sql/hnsw.sql:85: INFO:  done saving 8 vectors
 CREATE INDEX
 SELECT * FROM ldb_get_indexes('small_world');
-       indexname        |  size  |                                                         indexdef                                                         
-------------------------+--------+--------------------------------------------------------------------------------------------------------------------------
- small_world_vector_idx | 176 kB | CREATE INDEX small_world_vector_idx ON public.small_world USING hnsw (vector) WITH (m='11', ef='2', ef_construction='2')
+       indexname        | size  |                                                         indexdef                                                         
+------------------------+-------+--------------------------------------------------------------------------------------------------------------------------
+ small_world_vector_idx | 24 kB | CREATE INDEX small_world_vector_idx ON public.small_world USING hnsw (vector) WITH (m='11', ef='2', ef_construction='2')
 (1 row)
 
 SELECT * FROM (

--- a/test/expected/hnsw_insert.out
+++ b/test/expected/hnsw_insert.out
@@ -228,7 +228,7 @@ SELECT * from ldb_get_indexes('sift_base1k');
      indexname     |  size  |                                  indexdef                                   
 -------------------+--------+-----------------------------------------------------------------------------
  sift_base1k_pkey  | 40 kB  | CREATE UNIQUE INDEX sift_base1k_pkey ON public.sift_base1k USING btree (id)
- sift_base1k_v_idx | 872 kB | CREATE INDEX sift_base1k_v_idx ON public.sift_base1k USING hnsw (v)
+ sift_base1k_v_idx | 720 kB | CREATE INDEX sift_base1k_v_idx ON public.sift_base1k USING hnsw (v)
 (2 rows)
 
 INSERT INTO sift_base1k(v)
@@ -245,7 +245,7 @@ SELECT * from ldb_get_indexes('sift_base1k');
      indexname     |  size   |                                  indexdef                                   
 -------------------+---------+-----------------------------------------------------------------------------
  sift_base1k_pkey  | 48 kB   | CREATE UNIQUE INDEX sift_base1k_pkey ON public.sift_base1k USING btree (id)
- sift_base1k_v_idx | 1168 kB | CREATE INDEX sift_base1k_v_idx ON public.sift_base1k USING hnsw (v)
+ sift_base1k_v_idx | 1016 kB | CREATE INDEX sift_base1k_v_idx ON public.sift_base1k USING hnsw (v)
 (2 rows)
 
 INSERT INTO small_world (id, vector) VALUES ('xxx', NULL);

--- a/test/expected/hnsw_insert_array.out
+++ b/test/expected/hnsw_insert_array.out
@@ -226,7 +226,7 @@ SELECT * from ldb_get_indexes('sift_base1k');
      indexname     |  size  |                                       indexdef                                        
 -------------------+--------+---------------------------------------------------------------------------------------
  sift_base1k_pkey  | 40 kB  | CREATE UNIQUE INDEX sift_base1k_pkey ON public.sift_base1k USING btree (id)
- sift_base1k_v_idx | 872 kB | CREATE INDEX sift_base1k_v_idx ON public.sift_base1k USING hnsw (v) WITH (dims='128')
+ sift_base1k_v_idx | 720 kB | CREATE INDEX sift_base1k_v_idx ON public.sift_base1k USING hnsw (v) WITH (dims='128')
 (2 rows)
 
 INSERT INTO sift_base1k(v)
@@ -243,7 +243,7 @@ SELECT * from ldb_get_indexes('sift_base1k');
      indexname     |  size   |                                       indexdef                                        
 -------------------+---------+---------------------------------------------------------------------------------------
  sift_base1k_pkey  | 48 kB   | CREATE UNIQUE INDEX sift_base1k_pkey ON public.sift_base1k USING btree (id)
- sift_base1k_v_idx | 1168 kB | CREATE INDEX sift_base1k_v_idx ON public.sift_base1k USING hnsw (v) WITH (dims='128')
+ sift_base1k_v_idx | 1016 kB | CREATE INDEX sift_base1k_v_idx ON public.sift_base1k USING hnsw (v) WITH (dims='128')
 (2 rows)
 
 INSERT INTO small_world (id, vector) VALUES ('xxx', NULL);


### PR DESCRIPTION
In this PR changing the logic how we allocate blockmap pages
first we allocate one blockmap page and then fill in data pages, when there's not enough space we allocate two more blockmap pages then again data pages, and so on
the number of blockmap pages increase by power of two

here's a little schema how blocks look like

hdr page -> blockmap page 1 -> data page 1, data page 2 ... data page gk -> blockmap page 2, blockmap page 3 -> data page gk + 1, data page gk + 2, .... data page gk + gf -> blockmap page 4 ... blockmap page 7 -> data page .... and so on