### PR TITLE
[FEATURE] Avoid spilling index into file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,8 +125,6 @@ if (${LANTERNDB_COPYNODES})
   target_compile_definitions(lanterndb PRIVATE LANTERNDB_COPYNODES)
 endif()
 
-target_compile_definitions(lanterndb PRIVATE _GNU_SOURCE)
-
 set(_script_file "lanterndb--${LANTERNDB_VERSION}.sql")
 set (_update_files
   sql/updates/0.0.1--0.0.2.sql

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -5,9 +5,6 @@
 #include <catalog/namespace.h>
 #include <catalog/pg_type.h>
 #include <storage/bufmgr.h>
-#include <sys/mman.h>  // `mmap`
-#include <sys/stat.h>  // `fstat` for file size
-#include <unistd.h>    // `open`, `close`
 #include <utils/array.h>
 #include <utils/lsyscache.h>
 #include <utils/memutils.h>
@@ -254,7 +251,7 @@ static void BuildIndex(
     assert(error == NULL);
 
     char *result_buf = NULL;
-    usearch_save(buildstate->usearch_index, NULL, &error, &result_buf);
+    usearch_save(buildstate->usearch_index, NULL, &result_buf, &error);
     assert(error == NULL);
     assert(result_buf != NULL);
     num_added_vectors = usearch_size(buildstate->usearch_index, &error);

--- a/src/hnsw/build.h
+++ b/src/hnsw/build.h
@@ -8,9 +8,6 @@
 #include "lib_interface.h"
 #include "usearch.h"
 
-/* Variables */
-extern const char *GLOBAL_HNSW_IDX_NAME;
-
 typedef struct HnswBuildState
 {
     /* Info */

--- a/src/hnsw/scan.c
+++ b/src/hnsw/scan.c
@@ -14,8 +14,6 @@
 
 PG_MODULE_MAGIC;
 
-const char *GLOBAL_HNSW_IDX_NAME = "/tmp/hnsw_postgres_debug.bin";
-
 /*
  * Prepare for an index scan
  */
@@ -34,7 +32,6 @@ IndexScanDesc ldb_ambeginscan(Relation index, int nkeys, int norderbys)
     scanstate = (HnswScanState *)palloc0(sizeof(HnswScanState));
     scanstate->first = true;
 
-    // scanstate->hnsw = hnsw_load(GLOBAL_HNSW_IDX_NAME, dimensions, 8000000);
     opts.connectivity = HnswGetM(index);
     opts.dimensions = dimensions;
     opts.expansion_add = HnswGetEfConstruction(index);


### PR DESCRIPTION
## Description
We will now provide `usearch_result_buf` argument to `usearch_save` function, which will collect the index info to our buffer, so we can remove unnecessary file i/o operations.

## Issue
https://github.com/lanterndata/lanterndb/issues/13

## Dependencies
https://github.com/Ngalstyan4/usearch/pull/2