### PR TITLE
Ezra/distance functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,12 +49,28 @@ message(STATUS "${CMAKE_COLOR_GREEN}Build type: ${CMAKE_BUILD_TYPE}${CMAKE_COLOR
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 find_package(PostgreSQL REQUIRED)
+find_package(AVX2)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(SOURCES_DIR "src")
 # todo:: list out all the files instead of glob
 file(GLOB SOURCES "${SOURCES_DIR}/**/*.c" "${SOURCES_DIR}/*.c")
+if(AVX2_FOUND)
+    # Convert SOURCES_DIR to an absolute path
+    get_filename_component(ABS_SOURCES_DIR "${SOURCES_DIR}" ABSOLUTE)
+
+    set(DISTFUNC_FILE_ABS_PATH "${ABS_SOURCES_DIR}/hnsw/distfunc.c")
+
+    get_source_file_property(current_flags ${DISTFUNC_FILE_ABS_PATH} COMPILE_FLAGS)
+    if(current_flags STREQUAL "NOTFOUND")
+        set(current_flags "") # Reset to empty string if not set before
+    endif()
+
+    # Modify the compile flags of the absolute path
+    set_source_files_properties(${DISTFUNC_FILE_ABS_PATH} PROPERTIES COMPILE_FLAGS "${current_flags} ${AVX2_C_FLAGS}")
+endif()
+
 
 set(USEARCH_USE_SIMSIMD OFF)
 set(USEARCH_LOOKUP_LABEL OFF)

--- a/cmake/FindAVX2.cmake
+++ b/cmake/FindAVX2.cmake
@@ -1,0 +1,312 @@
+#.rst:
+# FindAVX2
+# --------
+#
+# Finds AVX2 support
+#
+# This module can be used to detect AVX2 support in a C compiler.  If
+# the compiler supports AVX2, the flags required to compile with
+# AVX2 support are returned in variables for the different languages.
+# The variables may be empty if the compiler does not need a special
+# flag to support AVX2.
+#
+# The following variables are set:
+#
+# ::
+#
+#    AVX2_C_FLAGS - flags to add to the C compiler for AVX2 support
+#    AVX2_FOUND - true if AVX2 is detected
+#
+#=============================================================================
+
+set(_AVX2_REQUIRED_VARS)
+set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
+set(CMAKE_REQUIRED_QUIET ${AVX2_FIND_QUIETLY})
+
+# sample AVX2 source code to test
+set(AVX2_C_TEST_SOURCE
+"
+#include <immintrin.h>
+void parasail_memset___m256i(__m256i *b, __m256i c, size_t len)
+{
+    size_t i;
+    for (i=0; i<len; ++i) {
+        _mm256_store_si256(&b[i], c);
+    }
+}
+
+int foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    __m256i result =  _mm256_add_epi8(vOne,vOne);
+    return _mm_extract_epi16(_mm256_extracti128_si256(result,0),0);
+}
+int main(void) { return (int)foo(); }
+")
+
+# if these are set then do not try to find them again,
+# by avoiding any try_compiles for the flags
+if((DEFINED AVX2_C_FLAGS) OR (DEFINED HAVE_AVX2))
+else()
+  if(WIN32)
+    # MSVC can compile AVX intrinsics without the arch flag, however it
+    # will detect that AVX code is found and "consider using /arch:AVX".
+    set(AVX2_C_FLAG_CANDIDATES
+      "/arch:AVX"
+      "/arch:AVX2")
+  else()
+    set(AVX2_C_FLAG_CANDIDATES
+      #Empty, if compiler automatically accepts AVX2
+      " "
+      #GNU, Intel
+      "-march=core-avx2"
+      #clang
+      "-mavx2"
+    )
+  endif()
+
+  include(CheckCSourceCompiles)
+
+  foreach(FLAG IN LISTS AVX2_C_FLAG_CANDIDATES)
+    set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+    set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+    unset(HAVE_AVX2 CACHE)
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Try AVX2 C flag = [${FLAG}]")
+    endif()
+    check_c_source_compiles("${AVX2_C_TEST_SOURCE}" HAVE_AVX2)
+    set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+    if(HAVE_AVX2)
+      set(AVX2_C_FLAGS_INTERNAL "${FLAG}")
+      break()
+    endif()
+  endforeach()
+
+  unset(AVX2_C_FLAG_CANDIDATES)
+  
+  set(AVX2_C_FLAGS "${AVX2_C_FLAGS_INTERNAL}"
+    CACHE STRING "C compiler flags for AVX2 intrinsics")
+endif()
+
+list(APPEND _AVX2_REQUIRED_VARS AVX2_C_FLAGS)
+
+set(CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET_SAVE})
+
+if(_AVX2_REQUIRED_VARS)
+  include(FindPackageHandleStandardArgs)
+
+  find_package_handle_standard_args(AVX2
+                                    REQUIRED_VARS ${_AVX2_REQUIRED_VARS})
+
+  mark_as_advanced(${_AVX2_REQUIRED_VARS})
+
+  unset(_AVX2_REQUIRED_VARS)
+else()
+  message(SEND_ERROR "FindAVX2 requires C or CXX language to be enabled")
+endif()
+
+# begin tests for AVX2 specfic features
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set(SAFE_CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  set(SAFE_CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
+
+set(AVX2_C_TEST_SOURCE_SET1_EPI64X
+"
+#include <stdint.h>
+#include <immintrin.h>
+__m256i foo() {
+    __m256i vOne = _mm256_set1_epi64x(1);
+    return vOne;
+}
+int main(void) { foo(); return 0; }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_SET1_EPI64X}" HAVE_AVX2_MM256_SET1_EPI64X)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_SET_EPI64X
+"
+#include <stdint.h>
+#include <immintrin.h>
+__m256i foo() {
+    __m256i vOne = _mm256_set_epi64x(1,1,1,1);
+    return vOne;
+}
+int main(void) { foo(); return 0; }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_SET_EPI64X}" HAVE_AVX2_MM256_SET_EPI64X)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_INSERT64
+"
+#include <stdint.h>
+#include <immintrin.h>
+__m256i foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return _mm256_insert_epi64(vOne,INT64_MIN,0);
+}
+int main(void) { foo(); return 0; }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_INSERT64}" HAVE_AVX2_MM256_INSERT_EPI64)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_INSERT32
+"
+#include <stdint.h>
+#include <immintrin.h>
+__m256i foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return _mm256_insert_epi32(vOne,INT32_MIN,0);
+}
+int main(void) { foo(); return 0; }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_INSERT32}" HAVE_AVX2_MM256_INSERT_EPI32)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_INSERT16
+"
+#include <stdint.h>
+#include <immintrin.h>
+__m256i foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return _mm256_insert_epi16(vOne,INT16_MIN,0);
+}
+int main(void) { foo(); return 0; }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_INSERT16}" HAVE_AVX2_MM256_INSERT_EPI16)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_INSERT8
+"
+#include <stdint.h>
+#include <immintrin.h>
+__m256i foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return _mm256_insert_epi8(vOne,INT8_MIN,0);
+}
+int main(void) { foo(); return 0; }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_INSERT8}" HAVE_AVX2_MM256_INSERT_EPI8)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+
+set(AVX2_C_TEST_SOURCE_EXTRACT64
+"
+#include <stdint.h>
+#include <immintrin.h>
+int64_t foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return (int64_t)_mm256_extract_epi64(vOne,0);
+}
+int main(void) { return (int)foo(); }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_EXTRACT64}" HAVE_AVX2_MM256_EXTRACT_EPI64)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_EXTRACT32
+"
+#include <stdint.h>
+#include <immintrin.h>
+int32_t foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return (int32_t)_mm256_extract_epi32(vOne,0);
+}
+int main(void) { return (int)foo(); }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_EXTRACT32}" HAVE_AVX2_MM256_EXTRACT_EPI32)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_EXTRACT16
+"
+#include <stdint.h>
+#include <immintrin.h>
+int16_t foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return (int16_t)_mm256_extract_epi16(vOne,0);
+}
+int main(void) { return (int)foo(); }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_EXTRACT16}" HAVE_AVX2_MM256_EXTRACT_EPI16)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+set(AVX2_C_TEST_SOURCE_EXTRACT8
+"
+#include <stdint.h>
+#include <immintrin.h>
+int8_t foo() {
+    __m256i vOne = _mm256_set1_epi8(1);
+    return (int8_t)_mm256_extract_epi8(vOne,0);
+}
+int main(void) { return (int)foo(); }
+")
+
+if(AVX2_C_FLAGS)
+  include(CheckCSourceCompiles)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${AVX2_C_FLAGS}")
+  check_c_source_compiles("${AVX2_C_TEST_SOURCE_EXTRACT8}" HAVE_AVX2_MM256_EXTRACT_EPI8)
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+endif()
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set(CMAKE_C_FLAGS "${SAFE_CMAKE_C_FLAGS}")
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  set(CMAKE_C_FLAGS "${SAFE_CMAKE_C_FLAGS}")
+endif()

--- a/sql/lanterndb.sql
+++ b/sql/lanterndb.sql
@@ -13,6 +13,15 @@ COMMENT ON ACCESS METHOD hnsw IS 'LanternDB vector index access method. Can be c
 CREATE FUNCTION l2sq_dist(real[], real[]) RETURNS real
 	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION cosine_dist(real[], real[]) RETURNS real
+	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION l1_dist(real[], real[]) RETURNS real
+	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION l2_dist(real[], real[]) RETURNS real
+	AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 
 -- operators
 
@@ -21,12 +30,22 @@ CREATE OPERATOR <-> (
 	COMMUTATOR = '<->'
 );
 
+CREATE OPERATOR <=> (
+	LEFTARG = real[], RIGHTARG = real[], PROCEDURE = cosine_dist,
+	COMMUTATOR = '<=>'
+);
+
 
 -- operator classes
 CREATE OPERATOR CLASS ann_l2_ops
 	DEFAULT FOR TYPE real[] USING hnsw AS
 	OPERATOR 1 <-> (real[], real[]) FOR ORDER BY float_ops,
 	FUNCTION 1 l2sq_dist(real[], real[]);
+
+CREATE OPERATOR CLASS ann_cosine_ops
+	FOR TYPE real[] USING hnsw AS
+	OPERATOR 1 <=> (real[], real[]) FOR ORDER BY float_ops,
+	FUNCTION 1 cosine_dist(real[], real[]);
 
 -- conditionaly create operator class for vector type
 DO $$DECLARE type_exists boolean;

--- a/src/hnsw.h
+++ b/src/hnsw.h
@@ -18,4 +18,12 @@
 
 /* Exported functions */
 PGDLLEXPORT void _PG_init(void);
+
+/* Distance function enum */
+typedef enum {
+    L2SQUARE,
+    COSINE,
+    L1,
+    L2,
+} distance_function;
 #endif // LDB_HNSW_H

--- a/src/hnsw/distfunc.c
+++ b/src/hnsw/distfunc.c
@@ -4,6 +4,8 @@
 
 #include "math.h"
 
+#include "utils.h"
+
 extern float l2sq_dist_impl(float4 const* ax, float4 const* bx, float4 dim)
 {
     float4 distance = 0.0;
@@ -12,4 +14,31 @@ extern float l2sq_dist_impl(float4 const* ax, float4 const* bx, float4 dim)
         distance += diff * diff;
     }
     return distance;
+}
+
+extern float cosine_dist_impl(float4 const* ax, float4 const* bx, float4 dim)
+{
+    float4 dot = 0.0;
+    float4 mag_a = 0.0;
+    float4 mag_b = 0.0;
+    for (size_t i = 0; i < dim; i++) {
+        dot += ax[ i ] * bx[ i ];
+        mag_a += ax [ i ] * ax[ i ];
+        mag_b += bx [ i ] * bx[ i ];
+    }
+    return dot / sqrtf(mag_a * mag_b);
+}
+
+extern float l1_dist_impl(float4 const* ax, float4 const* bx, float4 dim)
+{
+    float4 distance = 0.0;
+    for (size_t i =0; i < dim; i++) {
+        distance += fabs(ax[ i ] - bx[ i ]);
+    }
+    return distance;
+}
+
+extern float l2_dist_impl(float4 const* ax, float4 const* bx, float4 dim)
+{
+    return sqrtf(l2sq_dist_impl(ax, bx, dim));
 }

--- a/src/hnsw/distfunc.c
+++ b/src/hnsw/distfunc.c
@@ -1,3 +1,8 @@
+#ifdef __linux__
+#include <immintrin.h>
+#include <cpuid.h>
+#endif
+
 #include "postgres.h"
 
 #include "distfunc.h"
@@ -6,34 +11,147 @@
 
 #include "utils.h"
 
+unsigned int AVX2_PRESENT = 0;
+
+#ifdef __linux__
+unsigned int CheckAVX(){
+    unsigned int eax, ebx, ecx, edx;
+    __get_cpuid(1, &eax, &ebx, &ecx, &edx);
+
+    // needed to preserve fp registers
+    if (!(ecx & bit_OSXSAVE) || !(ecx & bit_AVX)) {
+        return 0;
+    }
+
+    __get_cpuid_count(7, 0, &eax, &ebx, &ecx, &edx);
+    return (ebx & bit_AVX2) != 0;
+}
+
+__attribute__((constructor)) void InitLanternUtils()
+{
+    AVX2_PRESENT = CheckAVX();
+}
+#if defined(__AVX2__)
+static inline float SumAVXReg(float arr[8])
+{
+    return arr [ 0 ] + arr[ 1 ] + arr[ 2 ] + arr[ 3 ] + arr[ 4 ] + arr[ 5 ] + arr[ 6 ] + arr[ 7 ];
+}
+#endif
+#endif
+
 extern float l2sq_dist_impl(float4 const* ax, float4 const* bx, float4 dim)
 {
     float4 distance = 0.0;
-    for(size_t i = 0; i < dim; i++) {
-        float4 diff = ax[ i ] - bx[ i ];
-        distance += diff * diff;
+    if (AVX2_PRESENT && dim > 7) {
+#if defined(__AVX2__) && defined(__linux__)
+        __m256 acc = _mm256_setzero_ps();
+        size_t i;
+        for(i = 0; i+7 < dim; i += 8) {
+            __m256 as = _mm256_loadu_ps(ax + i);
+            __m256 bs = _mm256_loadu_ps(bx + i);
+            __m256 diff = _mm256_sub_ps(as, bs);
+            acc = _mm256_add_ps(acc, _mm256_mul_ps(diff, diff));
+        }
+
+        float result[8];
+        _mm256_storeu_ps(result, acc);
+        distance = SumAVXReg(result);
+
+        for (; i < dim; ++i) {
+            float4 diff = ax[ i ] - bx[ i ];
+            distance += diff * diff;
+        }
+#endif
+    }
+    else {
+        for(size_t i = 0; i < dim; i++) {
+            float4 diff = ax[ i ] - bx[ i ];
+            distance += diff * diff;
+        }
     }
     return distance;
 }
 
 extern float cosine_dist_impl(float4 const* ax, float4 const* bx, float4 dim)
 {
-    float4 dot = 0.0;
-    float4 mag_a = 0.0;
-    float4 mag_b = 0.0;
-    for (size_t i = 0; i < dim; i++) {
-        dot += ax[ i ] * bx[ i ];
-        mag_a += ax [ i ] * ax[ i ];
-        mag_b += bx [ i ] * bx[ i ];
+    float distance = 0.0;
+    if (AVX2_PRESENT && dim > 7){
+#if defined(__AVX2__) && defined(__linux__)
+        __m256 dot = _mm256_setzero_ps();
+        __m256 mag_a = _mm256_setzero_ps();
+        __m256 mag_b = _mm256_setzero_ps();
+        size_t i;
+        for(i = 0; i+7 < dim; i += 8) {
+            __m256 as = _mm256_loadu_ps(ax + i);
+            __m256 bs = _mm256_loadu_ps(bx + i);
+            dot = _mm256_add_ps(dot, _mm256_mul_ps(as, bs));
+            mag_a = _mm256_add_ps(mag_a, _mm256_mul_ps(as, as));
+            mag_b = _mm256_add_ps(mag_b, _mm256_mul_ps(bs, bs));
+        }
+
+        float mag_a_res[8];
+        float mag_b_res[8];
+        float dot_res[8];
+
+        _mm256_storeu_ps(mag_a_res, mag_a);
+        _mm256_storeu_ps(mag_b_res, mag_b);
+        _mm256_storeu_ps(dot_res, dot);
+
+        float dotf = SumAVXReg(dot_res);
+        float mag_af = SumAVXReg(mag_a_res);
+        float mag_bf = SumAVXReg(mag_b_res);
+
+        for (; i < dim; ++i) {
+            dotf += ax[ i ] * bx[ i ];
+            mag_af += ax [ i ] * ax[ i ];
+            mag_bf += bx [ i ] * bx[ i ];
+        }
+        distance = dotf / sqrtf(mag_af * mag_bf);
+#endif
     }
-    return dot / sqrtf(mag_a * mag_b);
+    else {
+        float4 dot = 0.0;
+        float4 mag_a = 0.0;
+        float4 mag_b = 0.0;
+        for (size_t i = 0; i < dim; i++) {
+            dot += ax[ i ] * bx[ i ];
+            mag_a += ax [ i ] * ax[ i ];
+            mag_b += bx [ i ] * bx[ i ];
+        }
+        distance =  dot / sqrtf(mag_a * mag_b);
+    }
+    return distance;
 }
 
 extern float l1_dist_impl(float4 const* ax, float4 const* bx, float4 dim)
 {
     float4 distance = 0.0;
-    for (size_t i =0; i < dim; i++) {
-        distance += fabs(ax[ i ] - bx[ i ]);
+    if (AVX2_PRESENT && dim > 7){
+#if defined(__AVX2__) && defined(__linux__)
+        __m256 acc = _mm256_setzero_ps();
+        __m256 mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x7FFFFFFF));
+        size_t i;
+        for(i = 0; i+7 < dim; i += 8) {
+            __m256 as = _mm256_loadu_ps(ax + i);
+            __m256 bs = _mm256_loadu_ps(bx + i);
+            __m256 diff = _mm256_sub_ps(as, bs);
+            acc = _mm256_add_ps(acc, _mm256_and_ps(diff, mask));
+        }
+
+        float result[8];
+        _mm256_storeu_ps(result, acc);
+        distance = SumAVXReg(result);
+
+        for (; i < dim; ++i) {
+            distance += fabs(ax[ i ] - bx[ i ]);
+        }
+#endif
+    }
+    else {
+        for (size_t i =0; i < dim; i++) {
+            distance += fabs(ax[ i ] - bx[ i ]);
+        }
+
     }
     return distance;
 }

--- a/src/hnsw/distfunc.h
+++ b/src/hnsw/distfunc.h
@@ -3,4 +3,7 @@
 #include <catalog/pg_type.h>
 
 extern float4 l2sq_dist_impl(float4 const* ax, float4 const* bx, float4 dim);
+extern float4 cosine_dist_impl(float4 const* ax, float4 const* bx, float4 dim);
+extern float4 l1_dist_impl(float4 const* ax, float4 const* bx, float4 dim);
+extern float4 l2_dist_impl(float4 const* ax, float4 const* bx, float4 dim);
 #endif  // LDB_HNSW_DISTFUNC_H

--- a/src/hnsw/utils.h
+++ b/src/hnsw/utils.h
@@ -6,5 +6,6 @@
 
 void LogUsearchOptions(usearch_init_options_t *opts);
 void PopulateUsearchOpts(Relation index, usearch_init_options_t *opts);
+
 #define UTILS_H
 #endif  // LDB_HNSW_UTILS_H


### PR DESCRIPTION
Initial implementations of AVX2 vectorized distance functions for linux-x86_64 (L1, L2, L2SQ, cosine). It should be fairly easy to extend it to BSD and intel macs, windows will require a separate implementation. I tested the code, and I'm reasonably confident it works. I have yet to profile it, but I wanted to get eyes on it before going much further. The choice of dim=8 to switch to the vectorized path was convenient for testing but is almost certainly premature. My hope is that this will provide a significant performance increase on vectors of higher dimension. I added a CMake file to detect AVX to support building distfunc.c with avx2 enabled as well which makes up the bulk of this PR