### PR TITLE
Docker CI Improvements

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -7,11 +7,6 @@ on:
         description: "Extension version"
         required: true
         default: "0.1"
-      PG_VERSION:
-        type: string
-        description: "Version of the postgres image"
-        required: true
-        default: "15"
       IMAGE_NAME:
         type: string
         description: "Container image name to tag"
@@ -20,6 +15,15 @@ on:
 jobs:
   ubuntu:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - postgres: 15
+          - postgres: 14
+          - postgres: 13
+          - postgres: 12
+          - postgres: 11
     steps:
       - uses: actions/checkout@v3
         with:
@@ -40,5 +44,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            PG_VERSION=${{ inputs.PG_VERSION }}
-          tags: ${{ inputs.IMAGE_NAME}}:latest,${{ inputs.IMAGE_NAME }}:${{ inputs.VERSION }}
+            PG_VERSION=${{ matrix.postgres }}
+          # tag latest only for pg15 version
+          tags: ${{ (matrix.postgres == 15 && format('{0}:latest', inputs.IMAGE_NAME) || '') }},${{ inputs.IMAGE_NAME }}:${{ inputs.VERSION }}-pg${{ matrix.postgres }}

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -45,5 +45,6 @@ jobs:
           push: true
           build-args: |
             PG_VERSION=${{ matrix.postgres }}
-          # tag latest only for pg15 version
-          tags: ${{ (matrix.postgres == 15 && format('{0}:latest', inputs.IMAGE_NAME) || '') }},${{ inputs.IMAGE_NAME }}:${{ inputs.VERSION }}-pg${{ matrix.postgres }}
+          # the :latest tag will refer to pg15 version
+          # but we will also include :latest-pg$v tag
+          tags: ${{ (matrix.postgres == 15 && format('{0}:latest', inputs.IMAGE_NAME) || '') }},${{ inputs.IMAGE_NAME }}:latest-pg${{ matrix.postgres }},${{ inputs.IMAGE_NAME }}:${{ inputs.VERSION }}-pg${{ matrix.postgres }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PG_VERSION=15
-FROM postgres:$PG_VERSION
+FROM postgres:$PG_VERSION-bookworm
 ARG PG_VERSION
 
 COPY . /tmp/lanterndb


### PR DESCRIPTION
## Description
Currently we are only publishing docker image for one postgres version and with tag `lanterndb:$version`, with this PR we are adding ability to publish docker images on all supported postgres versions at once, and the tag will be `lanterndb:$version-pg$pg_version`.

The example of published images can be found at https://hub.docker.com/r/varik77/lanterndb/tags

I have specified `bookworm` distro name in `Dockerfile` as `postgres:11` image without specifying the distro name is failing to update apt repositories.

The `:latest` version tag will only be published with postgres version 15, so `lanterndata/lanterndb:latest` will refer to latest extension version on latest postgres version supported 