### PR TITLE
Added a missing import

### DIFF
--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -8,6 +8,7 @@
 #include <utils/array.h>
 #include <utils/lsyscache.h>
 #include <utils/memutils.h>
+#include <sys/stat.h>
 
 #include "bench.h"
 #include "external_index.h"


### PR DESCRIPTION
# Description

After following the command lines from Quickstart, the build failed with the following error message:

```
[  7%] Building CXX object third_party/usearch/c/CMakeFiles/usearch_c.dir/lib.cpp.o
clang: warning: argument unused during compilation: '-static-libstdc++' [-Wunused-command-line-argument]
[ 14%] Linking CXX static library ../../../libusearch_c.a
[ 14%] Built target usearch_c
[ 21%] Building C object CMakeFiles/lanterndb.dir/src/hnsw.c.o
[ 28%] Building C object CMakeFiles/lanterndb.dir/src/hnsw/build.c.o
/Users/suhyunkim/git/lanterndb/src/hnsw/build.c:232:28: error: variable has incomplete type 'struct stat'
    struct stat            file_stat;
                           ^
/Users/suhyunkim/git/lanterndb/src/hnsw/build.c:232:12: note: forward declaration of 'struct stat'
    struct stat            file_stat;
           ^
1 error generated.
make[2]: *** [CMakeFiles/lanterndb.dir/src/hnsw/build.c.o] Error 1
make[1]: *** [CMakeFiles/lanterndb.dir/all] Error 2
make: *** [all] Error 2
```

# Steps To Reproduce the Behavior

```
git clone --recursive https://github.com/lanterndata/lanterndb.git
cd lanterndb
mkdir build
cd build
cmake ..
```

`cmake ..` fails due to a missing import. 

# Fix
Add `include <sys/stat.h>` in the `src/hnsw/build.c` file. 

# Contributors
@yumyumqing @gitskim



