### PR TITLE
Fixed cache memory allocation bug

### DIFF
--- a/scripts/livedebug.py
+++ b/scripts/livedebug.py
@@ -13,6 +13,14 @@ import time
 import argparse
 
 sql_common_script_path = os.path.join(os.path.dirname(__file__), "../test/sql/test_helpers/common.sql")
+default_user = ""
+
+try:
+    # this function is throwing an error inside container
+    default_user = os.getlogin()
+except:
+    default_user = "postgres"
+
 # helper functions
 def get_tmux_session_name() -> str:
     try:
@@ -32,7 +40,7 @@ def livedebug():
     parser = argparse.ArgumentParser(prog='livedebug',
                     description='Attaches gdb to postgres backend process for live debugging')
     parser.add_argument("-p", "--port",  default="5432", help="Port number")
-    parser.add_argument("-U", "--user",  default=os.getlogin(), help="Database user")
+    parser.add_argument("-U", "--user",  default=default_user, help="Database user")
     parser.add_argument("--usepgvector",  action='store_true', help="Initialize pgvector extension when resetting db")
     parser.add_argument("-H", "--host", default="localhost", help="Host name")
     parser.add_argument("--db", default="testdb", help="Database name", )

--- a/scripts/livedebug.py
+++ b/scripts/livedebug.py
@@ -32,7 +32,7 @@ def livedebug():
     parser = argparse.ArgumentParser(prog='livedebug',
                     description='Attaches gdb to postgres backend process for live debugging')
     parser.add_argument("-p", "--port",  default="5432", help="Port number")
-    parser.add_argument("-U", "--user",  default="postgres", help="Database user")
+    parser.add_argument("-U", "--user",  default=os.getlogin(), help="Database user")
     parser.add_argument("--usepgvector",  action='store_true', help="Initialize pgvector extension when resetting db")
     parser.add_argument("-H", "--host", default="localhost", help="Host name")
     parser.add_argument("--db", default="testdb", help="Database name", )
@@ -59,7 +59,7 @@ def livedebug():
         print("resetdb result", res)
 
     # 1. run the command through a shell
-    psql_command = f"psql -U {args.user} -P pager=off -p {args.port} -h {args.host} {args.db}"
+    psql_command = f"psql -U {args.user} -P pager=off -p {args.port} {args.db}"
     psql_process = subprocess.Popen(psql_command, shell=True, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
 
     # 2. forward terminal signals to psql

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -21,9 +21,11 @@ then
     mkdir -p $TMP_ROOT/vector_datasets
     pushd $TMP_ROOT/vector_datasets
         wget https://storage.googleapis.com/lanterndb/sift_base1k.csv
+        wget https://storage.googleapis.com/lanterndata/siftsmall/siftsmall_base.csv
         wget https://storage.googleapis.com/lanterndb/tsv_wiki_sample.csv
         # Convert vector to arrays to be used with real[] type
         cat sift_base1k.csv | sed -e 's/\[/{/g' | sed -e 's/\]/}/g' > sift_base1k_arrays.csv
+        cat siftsmall_base.csv | sed -e 's/\[/{/g' | sed -e 's/\]/}/g' > siftsmall_base_arrays.csv
     popd
 fi
 

--- a/src/hnsw/cache.c
+++ b/src/hnsw/cache.c
@@ -3,7 +3,7 @@
 Cache cache_create()
 {
     Cache         cache;
-    MemoryContext ctx = AllocSetContextCreate(PortalContext, "BlockNumber cache", ALLOCSET_DEFAULT_SIZES);
+    MemoryContext ctx = AllocSetContextCreate(CacheMemoryContext, "BlockNumber cache", ALLOCSET_DEFAULT_SIZES);
 
     HASHCTL hctl;
     hctl.keysize = sizeof(CacheKey);

--- a/test/expected/hnsw_large_table.out
+++ b/test/expected/hnsw_large_table.out
@@ -1,0 +1,31 @@
+-- The goals here are:
+-- Test blockmap creation logic (triggered only after 2k vectors)
+-- perhaps do some lightweight benchmarking
+ CREATE TABLE sift_base10k (
+     id SERIAL PRIMARY KEY,
+     v real[128]
+);
+ CREATE INDEX hnsw_idx ON sift_base10k USING hnsw (v dist_l2sq_ops) WITH (M=2, ef_construction=10, ef=4, dims=128);
+INFO:  done init usearch index
+INFO:  inserted 0 elements
+INFO:  done saving 0 vectors
+ -- insert
+ \copy sift_base10k (v) FROM '/tmp/lanterndb/vector_datasets/siftsmall_base_arrays.csv' with csv;
+--  DROP INDEX hnsw_idx;
+--  \dt+
+--  \di+
+ -- bulk insert on create
+CREATE INDEX hnsw_idx2 ON sift_base10k USING hnsw (v dist_l2sq_ops) WITH (M=2, ef_construction=10, ef=4, dims=128);
+INFO:  done init usearch index
+INFO:  inserted 10000 elements
+INFO:  done saving 10000 vectors
+SELECT V AS v4444  FROM sift_base10k WHERE id = 4444 \gset
+EXPLAIN SELECT * FROM sift_base10k order by v <-> :'v4444'
+LIMIT 10;
+                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=0.00..5.98 rows=10 width=40)
+   ->  Index Scan using hnsw_idx2 on sift_base10k  (cost=0.00..5984.00 rows=10000 width=40)
+         Order By: (v <-> '{55,61,11,4,5,2,13,24,65,49,13,9,23,37,94,38,54,11,14,14,40,31,50,44,53,4,0,0,27,17,8,34,12,10,4,4,22,52,68,53,9,2,0,0,2,116,119,64,119,2,0,0,2,30,119,119,116,5,0,8,47,9,5,60,7,7,10,23,56,50,23,5,28,68,6,18,24,65,50,9,119,75,3,0,1,8,12,85,119,11,4,6,8,9,5,74,25,11,8,20,18,12,2,21,11,90,25,32,33,15,2,9,84,67,8,4,22,31,11,33,119,30,3,6,0,0,0,26}'::real[])
+(3 rows)
+

--- a/test/schedule.txt
+++ b/test/schedule.txt
@@ -1,2 +1,1 @@
-test: debug_helpers embedding_options hnsw hnsw_insert hnsw_insert_array hnsw_insert_empty_table hnsw_type_checks wiki hnsw_dist_func 
-ignore: hnsw_operators_todo
+test: debug_helpers embedding_options hnsw hnsw_insert hnsw_insert_array hnsw_insert_empty_table hnsw_type_checks wiki hnsw_dist_func hnsw_large_table

--- a/test/sql/hnsw_large_table.sql
+++ b/test/sql/hnsw_large_table.sql
@@ -17,7 +17,7 @@
  -- bulk insert on create
 CREATE INDEX hnsw_idx2 ON sift_base10k USING hnsw (v dist_l2sq_ops) WITH (M=2, ef_construction=10, ef=4, dims=128);
 SELECT V AS v4444  FROM sift_base10k WHERE id = 4444 \gset
-EXPLAIN (ANALYZE, TIMING FALSE) SELECT * FROM sift_base10k order by v <-> :'v4444'
+EXPLAIN SELECT * FROM sift_base10k order by v <-> :'v4444'
 LIMIT 10;
 
 

--- a/test/sql/hnsw_large_table.sql
+++ b/test/sql/hnsw_large_table.sql
@@ -1,0 +1,23 @@
+-- The goals here are:
+-- Test blockmap creation logic (triggered only after 2k vectors)
+-- perhaps do some lightweight benchmarking
+
+ CREATE TABLE sift_base10k (
+     id SERIAL PRIMARY KEY,
+     v real[128]
+);
+
+
+ CREATE INDEX hnsw_idx ON sift_base10k USING hnsw (v dist_l2sq_ops) WITH (M=2, ef_construction=10, ef=4, dims=128);
+ -- insert
+ \copy sift_base10k (v) FROM '/tmp/lanterndb/vector_datasets/siftsmall_base_arrays.csv' with csv;
+--  DROP INDEX hnsw_idx;
+--  \dt+
+--  \di+
+ -- bulk insert on create
+CREATE INDEX hnsw_idx2 ON sift_base10k USING hnsw (v dist_l2sq_ops) WITH (M=2, ef_construction=10, ef=4, dims=128);
+SELECT V AS v4444  FROM sift_base10k WHERE id = 4444 \gset
+EXPLAIN (ANALYZE, TIMING FALSE) SELECT * FROM sift_base10k order by v <-> :'v4444'
+LIMIT 10;
+
+


### PR DESCRIPTION
We were allocating cache memory in  `PortalContext` and it seems that after we free that memory postgres was also trying to free it when cleaning `PortalContext`. 
Simple solution is to allocate the memory in `CacheMemoryContext` which lives longer, this change will not cause memory leaks, as we are destroying the cache memory after end scan and insert operations.

Relates to #61 