### PR TITLE
Add lanterndb_extras package into release

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -67,7 +67,9 @@ jobs:
           path: /tmp/lanterndb-package
       - name: Create universal package
         id: package
-        run: sudo su -c "GITHUB_OUTPUT=$GITHUB_OUTPUT ./ci/scripts/universal-package.sh"
+        run: sudo su -c "GITHUB_OUTPUT=$GITHUB_OUTPUT PACKAGE_EXTRAS=1 GITHUB_TOKEN=$GITHUB_TOKEN ./ci/scripts/universal-package.sh"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/ci/scripts/universal-package.sh
+++ b/ci/scripts/universal-package.sh
@@ -34,6 +34,19 @@ for f in $(find "." -name "*.tar"); do
     cp $current_archive_name/src/*.so $current_dest_folder/
 done
 
+if [ ! -z "$PACKAGE_EXTRAS" ]
+then
+    EXTRAS_REPO=lanterndata/lanterndb_extras
+    EXTRAS_TAG_NAME=$(gh release list --repo $EXTRAS_REPO | head -n 1 |  awk '{print $3}')
+    if [ ! -z "$EXTRAS_TAG_NAME" ]
+    then
+      gh release download --repo $EXTRAS_REPO $EXTRAS_TAG_NAME
+      tar xf lanterndb-extras-*.tar && rm -f lanterndb-extras-*.tar && mv lanterndb-extras* $OUTPUT_DIR
+    else
+        echo "No release tag found for lanterndb_extras package"
+    fi
+fi
+
 cd /tmp && tar cf ${PACKAGE_NAME}.tar $PACKAGE_NAME
 echo "package_name=${PACKAGE_NAME}.tar" >> $GITHUB_OUTPUT
 echo "package_path=/tmp/${PACKAGE_NAME}.tar" >> $GITHUB_OUTPUT

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -15,7 +15,7 @@ for f in $(find "${SOURCE_DIR}/sql/updates/" -name "*.sql"); do
     cp $f ${BUILD_DIR}/${PACKAGE_NAME}/src/${dest_filename}
 done
 
-cp ${SOURCE_DIR}/lanterndb.control ${BUILD_DIR}/${PACKAGE_NAME}/src
+cp ${BUILD_DIR}/lanterndb.control ${BUILD_DIR}/${PACKAGE_NAME}/src
 
 cd ${BUILD_DIR} && tar cf ${PACKAGE_NAME}.tar ${PACKAGE_NAME}
 rm -rf ${BUILD_DIR}/${PACKAGE_NAME}

--- a/scripts/packaging/install.sh
+++ b/scripts/packaging/install.sh
@@ -49,3 +49,11 @@ cp -r shared/*.sql $PG_EXTENSION_DIR
 cp -r shared/*.control $PG_EXTENSION_DIR
 
 echo "LanternDB installed successfully"
+
+EXTRAS_PACKAGE_NAME=$(find . -name "lanterndb-extras*" | head -n 1)
+
+if [ ! -z "$EXTRAS_PACKAGE_NAME" ]
+then
+  echo "Installing LanternDB Extras"
+  cd $EXTRAS_PACKAGE_NAME && make install
+fi

--- a/scripts/packaging/uninstall.sh
+++ b/scripts/packaging/uninstall.sh
@@ -15,6 +15,6 @@ PG_EXTENSION_DIR=$($PG_CONFIG --sharedir)/extension
 
 rm -rf $PG_LIBRARY_DIR/lanterndb*.so
 rm -rf $PG_EXTENSION_DIR/lanterndb*.sql
-rm -rf $PG_EXTENSION_DIR/lanterndb.control
+rm -rf $PG_EXTENSION_DIR/lanterndb*.control
 
 echo "LanternDB uninstalled successfully"


### PR DESCRIPTION
## Description
When creating an archive package, we will now download the latest release from [LanternDB Extras](https://github.com/lanterndata/lanterndb_extras) repo and add it to our release too. 
The `make install` target of the package will check if lanterndb extras package files also exist, it will install lanterndb extras too.

PR in lanterndb extras: https://github.com/lanterndata/lanterndb_extras/pull/1
## Issue
#58 