### PR TITLE
Enable dynamic undefined symbols in shared libraries on Apple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ foreach(_dir ${PostgreSQL_SERVER_LIBRARY_DIRS})
 endforeach()
 
 if(APPLE)
-  set(_link_flags "${_link_flags} -bundle_loader ${PG_BINARY}")
+  set(_link_flags "${_link_flags} -bundle_loader ${PG_BINARY} -undefined dynamic_lookup")
 endif()
 
 


### PR DESCRIPTION
…

The default in new mac systems seems to be that undefined symbols are allowed in shared libraries. This is the default in linux systems as well.

So far we assumed all mac systems allow undefined symbols in shared libraries. But that is not the case and old linkers need the extra flag