### PR TITLE
Switch LINKER_LANGUAGE from C to CXX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ if(NOT APPLE)
   set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "")
   set(CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES "")
 endif()
-set_target_properties(lanterndb PROPERTIES LINKER_LANGUAGE C)
+set_target_properties(lanterndb PROPERTIES LINKER_LANGUAGE CXX)
 
 target_include_directories(lanterndb PRIVATE "./third_party/usearch/c")
 target_link_directories(lanterndb PRIVATE "./src")


### PR DESCRIPTION
On compiling postgresql and lanterndb from source from scratch, without installing postgresql core, the lanterndb extension compiles and installs, but it is unable to execute `CREATE EXTENSION lanterndb;` with the error `undefined symbol: _ZTVN10__cxxabiv117__class_type_infoE`. This is due to libstc++ not being linked. Switching the LINKER_LANGUAGE to CXX allows the build system to use a C++ linker and solves the issue.

References:
- https://github.com/sensational/sassphp/issues/4
- https://github.com/Iorethan/opencv_pfm/issues/1