### PR TITLE
Add ability to load index from file

### DIFF
--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -46,6 +46,19 @@ then
     echo "Successfully Downloaded all necessary vector test files"
 fi
 
+# if $TMP_ROOT/files does not exist
+# create the folder
+if [ ! -d "$TMP_ROOT/files" ]
+then
+    mkdir -p $TMP_ROOT/files
+    echo "Downloading necessary files for tests..."
+    pushd $TMP_ROOT/files
+       curl -sSo index-sift1k-cos.usearch https://storage.googleapis.com/lanterndata/lanterndb_binary_indexes/index-sift1k-cos.usearch
+       curl -sSo index-sift1k-l2.usearch https://storage.googleapis.com/lanterndata/lanterndb_binary_indexes/index-sift1k-l2.usearch
+    popd
+    echo "Successfully downloaded all necessary test files"
+fi
+
 # Check if pgvector is available
 pgvector_installed=$($PSQL -U $DB_USER -c "SELECT 1 FROM pg_available_extensions WHERE name = 'vector'" -tA)
 

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -315,12 +315,11 @@ static void ScanTable(HnswBuildState *buildstate)
 static void BuildIndex(
     Relation heap, Relation index, IndexInfo *indexInfo, HnswBuildState *buildstate, ForkNumber forkNum)
 {
-    InitBuildState(buildstate, heap, index, indexInfo);
-
     usearch_error_t        error = NULL;
     usearch_init_options_t opts;
     MemSet(&opts, 0, sizeof(opts));
 
+    InitBuildState(buildstate, heap, index, indexInfo);
     opts.dimensions = buildstate->dimensions;
     PopulateUsearchOpts(index, &opts);
 

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -72,14 +72,14 @@ static void AddTupleToUsearchIndex(ItemPointer tid, Datum *values, HnswBuildStat
             pg_unreachable();
     }
 
-        // casting tid structure to a number to be used as value in vector search
-        // tid has info about disk location of this item and is 6 bytes long
+    // casting tid structure to a number to be used as value in vector search
+    // tid has info about disk location of this item and is 6 bytes long
+    usearch_label_t label = GetUsearchLabel(tid);
 #ifdef LANTERN_USE_LIBHNSW
-    if(buildstate->hnsw != NULL) hnsw_add(buildstate->hnsw, vector, *(unsigned long *)tid);
+    if(buildstate->hnsw != NULL) hnsw_add(buildstate->hnsw, vector, label);
 #endif
 #ifdef LANTERN_USE_USEARCH
-    if(buildstate->usearch_index != NULL)
-        usearch_add(buildstate->usearch_index, *(unsigned long *)tid, vector, usearch_scalar, &error);
+    if(buildstate->usearch_index != NULL) usearch_add(buildstate->usearch_index, label, vector, usearch_scalar, &error);
 #endif
     assert(error == NULL);
     buildstate->tuples_indexed++;
@@ -249,6 +249,7 @@ static void InitBuildState(HnswBuildState *buildstate, Relation heap, Relation i
     buildstate->indexInfo = indexInfo;
     buildstate->columnType = GetIndexColumnType(index);
     buildstate->dimensions = GetHnswIndexDimensions(index);
+    buildstate->index_file_path = HnswGetIndexFilePath(index);
 
     // If a dimension wasn't specified try to infer it
     if(buildstate->dimensions < 1) {
@@ -314,28 +315,42 @@ static void ScanTable(HnswBuildState *buildstate)
 static void BuildIndex(
     Relation heap, Relation index, IndexInfo *indexInfo, HnswBuildState *buildstate, ForkNumber forkNum)
 {
+    InitBuildState(buildstate, heap, index, indexInfo);
+
+    usearch_error_t        error = NULL;
     usearch_init_options_t opts;
     MemSet(&opts, 0, sizeof(opts));
-    InitBuildState(buildstate, heap, index, indexInfo);
 
     opts.dimensions = buildstate->dimensions;
     PopulateUsearchOpts(index, &opts);
 
-    usearch_error_t error = NULL;
-    buildstate->hnsw = NULL;
     buildstate->usearch_index = usearch_init(&opts, &error);
-
     elog(INFO, "done init usearch index");
     assert(error == NULL);
 
-    usearch_reserve(buildstate->usearch_index, 1100000, &error);
-    assert(error == NULL);
+    buildstate->hnsw = NULL;
+    if(buildstate->index_file_path) {
+        usearch_load(buildstate->usearch_index, buildstate->index_file_path, &error);
+        assert(error == NULL);
+        elog(INFO, "done loading usearch index");
 
-    UpdateProgress(PROGRESS_CREATEIDX_PHASE, PROGRESS_HNSW_PHASE_IN_MEMORY_INSERT);
-    LanternBench("build hnsw index", ScanTable(buildstate));
+        // todo determine how we can set index rd_options
+        // HnswOptions *opts = (HnswOptions *)index->rd_options;
+        // opts->m = usearch_connectivity(buildstate->usearch_index, &error);
+        // assert(error == NULL);
+        // opts->dims = usearch_dimensions(buildstate->usearch_index, &error);
+        // assert(error == NULL);
+        // todo determine how to get ef construction and ef search params
+    } else {
+        usearch_reserve(buildstate->usearch_index, 1100000, &error);
+        assert(error == NULL);
 
-    elog(INFO, "inserted %ld elements", usearch_size(buildstate->usearch_index, &error));
-    assert(error == NULL);
+        UpdateProgress(PROGRESS_CREATEIDX_PHASE, PROGRESS_HNSW_PHASE_IN_MEMORY_INSERT);
+        LanternBench("build hnsw index", ScanTable(buildstate));
+
+        elog(INFO, "inserted %ld elements", usearch_size(buildstate->usearch_index, &error));
+        assert(error == NULL);
+    }
 
     char *result_buf = NULL;
     usearch_save(buildstate->usearch_index, NULL, &result_buf, &error);

--- a/src/hnsw/build.h
+++ b/src/hnsw/build.h
@@ -19,6 +19,7 @@ typedef struct HnswBuildState
     /* Settings */
     int            dimensions;
     HnswColumnType columnType;
+    char          *index_file_path;
 
     /* Statistics */
     double tuples_indexed;

--- a/src/hnsw/options.c
+++ b/src/hnsw/options.c
@@ -96,35 +96,6 @@ usearch_metric_kind_t HnswGetMetricKind(Relation index)
     }
 }
 
-static void HnswAlgorithmParamValidator(const char *value)
-{
-    if(value == NULL) {
-        ereport(ERROR,
-                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                 errmsg("Invalid algorithm value. Cannot b null"),
-                 errhint("Valid values are: 'own', 'diskann', "
-                         "'usearch', 'hnswlib'")));
-    }
-
-    if(strlen(value) > ALG_OPTION_MAX_STRING_LEN) {
-        ereport(ERROR,
-                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                 errmsg("Invalid algorithm value. Cannot be "
-                        "longer than %d characters",
-                        ALG_OPTION_MAX_STRING_LEN),
-                 errhint("Valid values are: 'own', 'diskann', "
-                         "'usearch', 'hnswlib'")));
-    }
-
-    if(strcmp(value, "own") != 0 && strcmp(value, "diskann") != 0 && strcmp(value, "usearch") != 0
-       && strcmp(value, "hnswlib") != 0) {
-        ereport(ERROR,
-                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-                 errmsg("Invalid algorithm value. Valid values are: "
-                        "'own', 'diskann', 'usearch', 'hnswlib'")));
-    }
-}
-
 static void IndexFileParamValidator(const char *value)
 {
     if(value == NULL) return;
@@ -145,8 +116,7 @@ bytea *ldb_amoptions(Datum reloptions, bool validate)
            {"m", RELOPT_TYPE_INT, offsetof(HnswOptions, m)},
            {"ef_construction", RELOPT_TYPE_INT, offsetof(HnswOptions, ef_construction)},
            {"ef", RELOPT_TYPE_INT, offsetof(HnswOptions, ef)},
-           {"_experimental_index_path", RELOPT_TYPE_STRING, offsetof(HnswOptions, experimantal_index_path_offset)},
-           {"alg", RELOPT_TYPE_STRING, offsetof(HnswOptions, alg_offset)}};
+           {"_experimental_index_path", RELOPT_TYPE_STRING, offsetof(HnswOptions, experimantal_index_path_offset)}};
 
 #if PG_VERSION_NUM >= 130000
     return (bytea *)build_reloptions(
@@ -247,16 +217,6 @@ void _PG_init(void)
                          "LanternDB expored index file path",
                          NULL,
                          IndexFileParamValidator
-#if PG_VERSION_NUM >= 130000
-                         ,
-                         AccessExclusiveLock
-#endif
-    );
-    add_string_reloption(ldb_hnsw_index_withopts,
-                         "alg",
-                         "Algorithm or specific search library to use for vector search",
-                         HNSW_DEFAULT_PROVIDER,
-                         HnswAlgorithmParamValidator
 #if PG_VERSION_NUM >= 130000
                          ,
                          AccessExclusiveLock

--- a/src/hnsw/options.h
+++ b/src/hnsw/options.h
@@ -39,7 +39,8 @@ typedef struct HnswOptions
     int   m;
     int   ef_construction;
     int   ef;
-    int   alg;
+    int   experimantal_index_path_offset;
+    int   alg_offset;
     // char[ALG_OPTION_MAX_STRING_LEN] alg;
 } HnswOptions;
 
@@ -48,9 +49,10 @@ int                   HnswGetM(Relation index);
 int                   HnswGetEfConstruction(Relation index);
 int                   HnswGetEf(Relation index);
 int                   HnswGetElementLimit(Relation index);
+char*                 HnswGetIndexFilePath(Relation index);
 usearch_metric_kind_t HnswGetMetricKind(Relation index);
 
-bytea *ldb_amoptions(Datum reloptions, bool validate);
+bytea* ldb_amoptions(Datum reloptions, bool validate);
 
 extern int ldb_hnsw_init_k;
 

--- a/src/hnsw/options.h
+++ b/src/hnsw/options.h
@@ -24,7 +24,6 @@
 #define HNSW_MAX_EF                   400
 #define HNSW_DEFAULT_PROVIDER         "usearch"
 #define HNSW_MAX_ELEMENT_LIMIT        200000000
-#define ALG_OPTION_MAX_STRING_LEN     32
 #define HNSWLIB_DEFAULT_ELEMENT_LIMIT 2000000
 
 #define LDB_HNSW_DEFAULT_K 10
@@ -40,8 +39,6 @@ typedef struct HnswOptions
     int   ef_construction;
     int   ef;
     int   experimantal_index_path_offset;
-    int   alg_offset;
-    // char[ALG_OPTION_MAX_STRING_LEN] alg;
 } HnswOptions;
 
 int                   HnswGetDims(Relation index);

--- a/src/hnsw/scan.c
+++ b/src/hnsw/scan.c
@@ -12,6 +12,7 @@
 #include "hnsw.h"
 #include "options.h"
 #include "retriever.h"
+#include "utils.h"
 #include "vector.h"
 
 /*
@@ -167,7 +168,7 @@ bool ldb_amgettuple(IndexScanDesc scan, ScanDirection dir)
     if(scanstate->first) {
         int             num_returned;
         Datum           value;
-        float4          *vec;
+        float4         *vec;
         usearch_error_t error = NULL;
         int             k = ldb_hnsw_init_k;
 

--- a/src/hnsw/utils.c
+++ b/src/hnsw/utils.c
@@ -109,3 +109,10 @@ int CheckOperatorUsage(const char *query)
     regfree(&regex2);
     return status;
 }
+
+usearch_label_t GetUsearchLabel(ItemPointer itemPtr)
+{
+    usearch_label_t label = 0;
+    memcpy((unsigned long *)&label, itemPtr, 6);
+    return label;
+}

--- a/src/hnsw/utils.h
+++ b/src/hnsw/utils.h
@@ -1,11 +1,12 @@
 #ifndef LDB_HNSW_UTILS_H
 #define LDB_HNSW_UTILS_H
-#include <utils/relcache.h>
+#include <access/amapi.h>
 
 #include "usearch.h"
 
-void LogUsearchOptions(usearch_init_options_t *opts);
-void PopulateUsearchOpts(Relation index, usearch_init_options_t *opts);
-int  CheckOperatorUsage(const char *query);
+void            LogUsearchOptions(usearch_init_options_t *opts);
+void            PopulateUsearchOpts(Relation index, usearch_init_options_t *opts);
+int             CheckOperatorUsage(const char *query);
+usearch_label_t GetUsearchLabel(ItemPointer itemPtr);
 #define UTILS_H
 #endif  // LDB_HNSW_UTILS_H

--- a/test/expected/hnsw_index_from_file.out
+++ b/test/expected/hnsw_index_from_file.out
@@ -11,6 +11,11 @@ CREATE TABLE IF NOT EXISTS sift_base1k (
     v REAL[]
 );
 COPY sift_base1k (v) FROM '/tmp/lanterndb/vector_datasets/sift_base1k_arrays.csv' WITH csv;
+-- Validate error on invalid path
+\set ON_ERROR_STOP off
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/invalid-path');
+ERROR:  Invalid index file path 
+\set ON_ERROR_STOP on
 -- Validate that creating an index from file works
 CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
 INFO:  done init usearch index
@@ -50,7 +55,37 @@ INFO:  usearch index initialized
  132455.00
 (10 rows)
 
-DROP INDEX hnsw_l2_index;
+-- Validate that inserting rows on index created from file works as expected
+INSERT INTO sift_base1k (v) VALUES 
+('{1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}'), 
+('{2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2}');
+SELECT v AS v1001 FROM sift_base1k WHERE id = 1001 \gset
+SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 10;
+INFO:  began scanning with 0 keys and 1 orderbys
+INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+INFO:  usearch index initialized
+   round   
+-----------
+      0.00
+    128.00
+ 249249.00
+ 249285.00
+ 249418.00
+ 249457.00
+ 249515.00
+ 249589.00
+ 249647.00
+ 249652.00
+(10 rows)
+
+-- Drop and recreate table
+DROP TABLE sift_base1k CASCADE;
+\ir utils/sift1k_array.sql
+CREATE TABLE IF NOT EXISTS sift_base1k (
+    id SERIAL,
+    v REAL[]
+);
+COPY sift_base1k (v) FROM '/tmp/lanterndb/vector_datasets/sift_base1k_arrays.csv' WITH csv;
 -- Validate that creating an index from file works with cosine distance function
 CREATE INDEX hnsw_cos_index ON sift_base1k USING hnsw (v dist_cos_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-cos.usearch');
 INFO:  done init usearch index
@@ -87,5 +122,116 @@ INFO:  usearch index initialized
   0.25
   0.25
   0.26
+(10 rows)
+
+--- Test scenarious ---
+-----------------------------------------
+-- Case 1:
+-- Index is created externally.
+-- More vectors are added to the table
+-- CREATE INDEX is run on the table with the external file
+DROP TABLE sift_base1k CASCADE;
+\ir utils/sift1k_array.sql
+CREATE TABLE IF NOT EXISTS sift_base1k (
+    id SERIAL,
+    v REAL[]
+);
+COPY sift_base1k (v) FROM '/tmp/lanterndb/vector_datasets/sift_base1k_arrays.csv' WITH csv;
+INSERT INTO sift_base1k (v) VALUES 
+('{1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}'), 
+('{2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2}');
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+INFO:  done init usearch index
+INFO:  done loading usearch index
+INFO:  done saving 1000 vectors
+-- The 1001 and 1002 vectors will be ignored in search, so the first row will not be 0 in result
+SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 10;
+INFO:  began scanning with 0 keys and 1 orderbys
+INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+INFO:  usearch index initialized
+   round   
+-----------
+ 249285.00
+ 249418.00
+ 249457.00
+ 249515.00
+ 249589.00
+ 249647.00
+ 249675.00
+ 249695.00
+ 249736.00
+ 249796.00
+(10 rows)
+
+-- Case 2:
+-- Index is created externally
+-- Vectors are deleted from the table
+-- CREATE INDEX is run on the table with external file
+DROP TABLE sift_base1k CASCADE;
+\ir utils/sift1k_array.sql
+CREATE TABLE IF NOT EXISTS sift_base1k (
+    id SERIAL,
+    v REAL[]
+);
+COPY sift_base1k (v) FROM '/tmp/lanterndb/vector_datasets/sift_base1k_arrays.csv' WITH csv;
+DELETE FROM sift_base1k WHERE id=777;
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+INFO:  done init usearch index
+INFO:  done loading usearch index
+INFO:  done saving 1000 vectors
+-- This should not throw error, but the first result will not be 0 as vector 777 is deleted from the table
+SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+INFO:  began scanning with 0 keys and 1 orderbys
+INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+INFO:  usearch index initialized
+   round   
+-----------
+  98486.00
+ 108785.00
+ 115194.00
+ 117411.00
+ 127293.00
+ 127986.00
+ 130663.00
+ 130863.00
+ 132455.00
+ 132813.00
+(10 rows)
+
+-- Case 3:
+-- Index is created externally
+-- Vectors updated
+-- CREATE INDEX is run on the table with external file
+DROP TABLE sift_base1k CASCADE;
+\ir utils/sift1k_array.sql
+CREATE TABLE IF NOT EXISTS sift_base1k (
+    id SERIAL,
+    v REAL[]
+);
+COPY sift_base1k (v) FROM '/tmp/lanterndb/vector_datasets/sift_base1k_arrays.csv' WITH csv;
+UPDATE  sift_base1k SET v=:'v1001' WHERE id=777;
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+INFO:  done init usearch index
+INFO:  done loading usearch index
+INFO:  done saving 1000 vectors
+-- The first row will not be 0 now as the vector under id=777 was updated to 1,1,1,1... but it was indexed with different vector
+-- So the usearch index can not find 1,1,1,1,1.. vector in the index and wrong results will be returned
+-- This is an expected behaviour for now
+SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 10;
+INFO:  began scanning with 0 keys and 1 orderbys
+INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+INFO:  usearch index initialized
+   round   
+-----------
+ 249285.00
+ 249418.00
+ 249457.00
+ 249515.00
+ 249589.00
+ 249647.00
+ 249675.00
+ 249695.00
+ 249736.00
+ 249796.00
 (10 rows)
 

--- a/test/expected/hnsw_index_from_file.out
+++ b/test/expected/hnsw_index_from_file.out
@@ -56,9 +56,9 @@ INFO:  usearch index initialized
 (10 rows)
 
 -- Validate that inserting rows on index created from file works as expected
-INSERT INTO sift_base1k (v) VALUES 
-('{1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}'), 
-('{2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2}');
+INSERT INTO sift_base1k (id, v) VALUES 
+(1001, array_fill(1, ARRAY[128])),
+(1002, array_fill(2, ARRAY[128]));
 SELECT v AS v1001 FROM sift_base1k WHERE id = 1001 \gset
 SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 10;
 INFO:  began scanning with 0 keys and 1 orderbys
@@ -126,44 +126,7 @@ INFO:  usearch index initialized
 
 --- Test scenarious ---
 -----------------------------------------
--- Case 1:
--- Index is created externally.
--- More vectors are added to the table
--- CREATE INDEX is run on the table with the external file
-DROP TABLE sift_base1k CASCADE;
-\ir utils/sift1k_array.sql
-CREATE TABLE IF NOT EXISTS sift_base1k (
-    id SERIAL,
-    v REAL[]
-);
-COPY sift_base1k (v) FROM '/tmp/lanterndb/vector_datasets/sift_base1k_arrays.csv' WITH csv;
-INSERT INTO sift_base1k (v) VALUES 
-('{1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}'), 
-('{2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2}');
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
-INFO:  done init usearch index
-INFO:  done loading usearch index
-INFO:  done saving 1000 vectors
--- The 1001 and 1002 vectors will be ignored in search, so the first row will not be 0 in result
-SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 10;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
-INFO:  usearch index initialized
-   round   
------------
- 249285.00
- 249418.00
- 249457.00
- 249515.00
- 249589.00
- 249647.00
- 249675.00
- 249695.00
- 249736.00
- 249796.00
-(10 rows)
-
--- Case 2:
+-- Case:
 -- Index is created externally
 -- Vectors are deleted from the table
 -- CREATE INDEX is run on the table with external file
@@ -196,42 +159,5 @@ INFO:  usearch index initialized
  130863.00
  132455.00
  132813.00
-(10 rows)
-
--- Case 3:
--- Index is created externally
--- Vectors updated
--- CREATE INDEX is run on the table with external file
-DROP TABLE sift_base1k CASCADE;
-\ir utils/sift1k_array.sql
-CREATE TABLE IF NOT EXISTS sift_base1k (
-    id SERIAL,
-    v REAL[]
-);
-COPY sift_base1k (v) FROM '/tmp/lanterndb/vector_datasets/sift_base1k_arrays.csv' WITH csv;
-UPDATE  sift_base1k SET v=:'v1001' WHERE id=777;
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
-INFO:  done init usearch index
-INFO:  done loading usearch index
-INFO:  done saving 1000 vectors
--- The first row will not be 0 now as the vector under id=777 was updated to 1,1,1,1... but it was indexed with different vector
--- So the usearch index can not find 1,1,1,1,1.. vector in the index and wrong results will be returned
--- This is an expected behaviour for now
-SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 10;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
-INFO:  usearch index initialized
-   round   
------------
- 249285.00
- 249418.00
- 249457.00
- 249515.00
- 249589.00
- 249647.00
- 249675.00
- 249695.00
- 249736.00
- 249796.00
 (10 rows)
 

--- a/test/expected/hnsw_index_from_file.out
+++ b/test/expected/hnsw_index_from_file.out
@@ -1,0 +1,91 @@
+------------------------------------------------------------------------------
+-- Test HNSW index creation from file
+------------------------------------------------------------------------------
+-- Index files were created with ldb-create-index program which source is under https://github.com/lanterndata/lanterndb_extras/
+-- We have exported index files for sift1k dataset for cosine and l2sq distances
+-- With the following params m=16 ef=64 ef_construction=128 dims=128
+-- Validate that index creation works with a small number of vectors
+\ir utils/sift1k_array.sql
+CREATE TABLE IF NOT EXISTS sift_base1k (
+    id SERIAL,
+    v REAL[]
+);
+COPY sift_base1k (v) FROM '/tmp/lanterndb/vector_datasets/sift_base1k_arrays.csv' WITH csv;
+-- Validate that creating an index from file works
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+INFO:  done init usearch index
+INFO:  done loading usearch index
+INFO:  done saving 1000 vectors
+SELECT * FROM ldb_get_indexes('sift_base1k');
+   indexname   |  size  |                                                                                              indexdef                                                                                              | total_index_size 
+---------------+--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
+ hnsw_l2_index | 720 kB | CREATE INDEX hnsw_l2_index ON public.sift_base1k USING hnsw (v) WITH (dims='128', m='16', ef='64', ef_construction='128', _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch') | 720 kB
+(1 row)
+
+SET enable_seqscan = false;
+SELECT v AS v777 FROM sift_base1k WHERE id = 777 \gset
+EXPLAIN (COSTS FALSE) SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_l2_index on sift_base1k
+         Order By: (v <-> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
+(3 rows)
+
+SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+INFO:  began scanning with 0 keys and 1 orderbys
+INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+INFO:  usearch index initialized
+   round   
+-----------
+      0.00
+  98486.00
+ 108785.00
+ 115194.00
+ 117411.00
+ 127293.00
+ 127986.00
+ 130663.00
+ 130863.00
+ 132455.00
+(10 rows)
+
+DROP INDEX hnsw_l2_index;
+-- Validate that creating an index from file works with cosine distance function
+CREATE INDEX hnsw_cos_index ON sift_base1k USING hnsw (v dist_cos_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-cos.usearch');
+INFO:  done init usearch index
+INFO:  done loading usearch index
+INFO:  done saving 1000 vectors
+SELECT * FROM ldb_get_indexes('sift_base1k');
+   indexname    |  size  |                                                                                                     indexdef                                                                                                      | total_index_size 
+----------------+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
+ hnsw_cos_index | 720 kB | CREATE INDEX hnsw_cos_index ON public.sift_base1k USING hnsw (v dist_cos_ops) WITH (dims='128', m='16', ef='64', ef_construction='128', _experimental_index_path='/tmp/lanterndb/files/index-sift1k-cos.usearch') | 720 kB
+(1 row)
+
+SELECT v AS v777 FROM sift_base1k WHERE id = 777 \gset
+EXPLAIN (COSTS FALSE) SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Index Scan using hnsw_cos_index on sift_base1k
+         Order By: (v <-> '{97,67,0,0,0,0,0,14,49,107,23,0,0,0,5,24,4,25,48,5,0,1,8,3,0,5,17,3,1,1,3,3,126,126,0,0,0,0,0,27,49,126,49,8,1,4,11,14,0,6,37,39,10,22,25,0,0,0,12,27,7,23,35,3,126,9,1,0,0,0,19,126,28,11,8,7,1,39,126,126,0,1,28,27,3,126,126,0,1,3,7,9,0,52,126,5,13,5,8,0,0,0,33,72,78,19,18,3,0,3,21,126,42,13,64,83,1,9,8,23,1,4,22,68,3,1,4,0}'::real[])
+(3 rows)
+
+SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+INFO:  began scanning with 0 keys and 1 orderbys
+INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+INFO:  usearch index initialized
+ round 
+-------
+  0.00
+  0.19
+  0.21
+  0.22
+  0.23
+  0.25
+  0.25
+  0.25
+  0.25
+  0.26
+(10 rows)
+

--- a/test/expected/hnsw_todo.out
+++ b/test/expected/hnsw_todo.out
@@ -84,3 +84,64 @@ INFO:  usearch index initialized
   2.00
 (4 rows)
 
+--- Test scenarious ---
+-----------------------------------------
+-- Case:
+-- Index is created externally.
+-- More vectors are added to the table
+-- CREATE INDEX is run on the table with the external file
+SELECT array_fill(0, ARRAY[128]) AS v0 \gset
+DROP TABLE IF EXISTS sift_base1k CASCADE;
+NOTICE:  table "sift_base1k" does not exist, skipping
+\ir utils/sift1k_array.sql
+CREATE TABLE IF NOT EXISTS sift_base1k (
+    id SERIAL,
+    v REAL[]
+);
+COPY sift_base1k (v) FROM '/tmp/lanterndb/vector_datasets/sift_base1k_arrays.csv' WITH csv;
+INSERT INTO sift_base1k (id, v) VALUES 
+(1001, array_fill(1, ARRAY[128])),
+(1102, array_fill(2, ARRAY[128]));
+SELECT v AS v1001 FROM sift_base1k WHERE id = 1001 \gset
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+INFO:  done init usearch index
+INFO:  done loading usearch index
+INFO:  done saving 1000 vectors
+-- The 1001 and 1002 vectors will be ignored in search, so the first row will not be 0 in result
+SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 1;
+INFO:  began scanning with 0 keys and 1 orderbys
+INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+INFO:  usearch index initialized
+   round   
+-----------
+0.00
+(1 row)
+
+-- Case:
+-- Index is created externally
+-- Vectors updated
+-- CREATE INDEX is run on the table with external file
+DROP TABLE sift_base1k CASCADE;
+\ir utils/sift1k_array.sql
+CREATE TABLE IF NOT EXISTS sift_base1k (
+    id SERIAL,
+    v REAL[]
+);
+COPY sift_base1k (v) FROM '/tmp/lanterndb/vector_datasets/sift_base1k_arrays.csv' WITH csv;
+UPDATE sift_base1k SET v=:'v1001' WHERE id=777;
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+INFO:  done init usearch index
+INFO:  done loading usearch index
+INFO:  done saving 1000 vectors
+-- The first row will not be 0 now as the vector under id=777 was updated to 1,1,1,1... but it was indexed with different vector
+-- So the usearch index can not find 1,1,1,1,1.. vector in the index and wrong results will be returned
+-- This is an expected behaviour for now
+SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 1;
+INFO:  began scanning with 0 keys and 1 orderbys
+INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+INFO:  usearch index initialized
+   round   
+-----------
+0.00
+(1 row)
+

--- a/test/schedule.txt
+++ b/test/schedule.txt
@@ -7,4 +7,4 @@
 
 ignore: hnsw_todo
 test_pgvector: hnsw_vector
-test: hnsw_config hnsw_correct hnsw_create hnsw_dist_func hnsw_insert hnsw_select hnsw_todo
+test: hnsw_config hnsw_correct hnsw_create hnsw_dist_func hnsw_insert hnsw_select hnsw_todo hnsw_index_from_file

--- a/test/sql/hnsw_index_from_file.sql
+++ b/test/sql/hnsw_index_from_file.sql
@@ -1,0 +1,30 @@
+------------------------------------------------------------------------------
+-- Test HNSW index creation from file
+------------------------------------------------------------------------------
+
+-- Index files were created with ldb-create-index program which source is under https://github.com/lanterndata/lanterndb_extras/
+-- We have exported index files for sift1k dataset for cosine and l2sq distances
+-- With the following params m=16 ef=64 ef_construction=128 dims=128
+-- Validate that index creation works with a small number of vectors
+\ir utils/sift1k_array.sql
+
+-- Validate that creating an index from file works
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+SELECT * FROM ldb_get_indexes('sift_base1k');
+
+SET enable_seqscan = false;
+
+SELECT v AS v777 FROM sift_base1k WHERE id = 777 \gset
+EXPLAIN (COSTS FALSE) SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+
+DROP INDEX hnsw_l2_index;
+
+-- Validate that creating an index from file works with cosine distance function
+CREATE INDEX hnsw_cos_index ON sift_base1k USING hnsw (v dist_cos_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-cos.usearch');
+SELECT * FROM ldb_get_indexes('sift_base1k');
+
+SELECT v AS v777 FROM sift_base1k WHERE id = 777 \gset
+EXPLAIN (COSTS FALSE) SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+

--- a/test/sql/hnsw_index_from_file.sql
+++ b/test/sql/hnsw_index_from_file.sql
@@ -8,6 +8,10 @@
 -- Validate that index creation works with a small number of vectors
 \ir utils/sift1k_array.sql
 
+-- Validate error on invalid path
+\set ON_ERROR_STOP off
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/invalid-path');
+\set ON_ERROR_STOP on
 -- Validate that creating an index from file works
 CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
 SELECT * FROM ldb_get_indexes('sift_base1k');
@@ -17,8 +21,16 @@ SET enable_seqscan = false;
 SELECT v AS v777 FROM sift_base1k WHERE id = 777 \gset
 EXPLAIN (COSTS FALSE) SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
 SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+-- Validate that inserting rows on index created from file works as expected
+INSERT INTO sift_base1k (v) VALUES 
+('{1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}'), 
+('{2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2}');
+SELECT v AS v1001 FROM sift_base1k WHERE id = 1001 \gset
+SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 10;
 
-DROP INDEX hnsw_l2_index;
+-- Drop and recreate table
+DROP TABLE sift_base1k CASCADE;
+\ir utils/sift1k_array.sql
 
 -- Validate that creating an index from file works with cosine distance function
 CREATE INDEX hnsw_cos_index ON sift_base1k USING hnsw (v dist_cos_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-cos.usearch');
@@ -28,3 +40,42 @@ SELECT v AS v777 FROM sift_base1k WHERE id = 777 \gset
 EXPLAIN (COSTS FALSE) SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
 SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
 
+--- Test scenarious ---
+-----------------------------------------
+-- Case 1:
+-- Index is created externally.
+-- More vectors are added to the table
+-- CREATE INDEX is run on the table with the external file
+
+DROP TABLE sift_base1k CASCADE;
+\ir utils/sift1k_array.sql
+INSERT INTO sift_base1k (v) VALUES 
+('{1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}'), 
+('{2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2}');
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+-- The 1001 and 1002 vectors will be ignored in search, so the first row will not be 0 in result
+SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 10;
+
+-- Case 2:
+-- Index is created externally
+-- Vectors are deleted from the table
+-- CREATE INDEX is run on the table with external file
+DROP TABLE sift_base1k CASCADE;
+\ir utils/sift1k_array.sql
+DELETE FROM sift_base1k WHERE id=777;
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+-- This should not throw error, but the first result will not be 0 as vector 777 is deleted from the table
+SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
+
+-- Case 3:
+-- Index is created externally
+-- Vectors updated
+-- CREATE INDEX is run on the table with external file
+DROP TABLE sift_base1k CASCADE;
+\ir utils/sift1k_array.sql
+UPDATE  sift_base1k SET v=:'v1001' WHERE id=777;
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+-- The first row will not be 0 now as the vector under id=777 was updated to 1,1,1,1... but it was indexed with different vector
+-- So the usearch index can not find 1,1,1,1,1.. vector in the index and wrong results will be returned
+-- This is an expected behaviour for now
+SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 10;

--- a/test/sql/hnsw_index_from_file.sql
+++ b/test/sql/hnsw_index_from_file.sql
@@ -22,9 +22,9 @@ SELECT v AS v777 FROM sift_base1k WHERE id = 777 \gset
 EXPLAIN (COSTS FALSE) SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
 SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
 -- Validate that inserting rows on index created from file works as expected
-INSERT INTO sift_base1k (v) VALUES 
-('{1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}'), 
-('{2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2}');
+INSERT INTO sift_base1k (id, v) VALUES 
+(1001, array_fill(1, ARRAY[128])),
+(1002, array_fill(2, ARRAY[128]));
 SELECT v AS v1001 FROM sift_base1k WHERE id = 1001 \gset
 SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 10;
 
@@ -42,21 +42,8 @@ SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :
 
 --- Test scenarious ---
 -----------------------------------------
--- Case 1:
--- Index is created externally.
--- More vectors are added to the table
--- CREATE INDEX is run on the table with the external file
 
-DROP TABLE sift_base1k CASCADE;
-\ir utils/sift1k_array.sql
-INSERT INTO sift_base1k (v) VALUES 
-('{1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}'), 
-('{2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2}');
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
--- The 1001 and 1002 vectors will be ignored in search, so the first row will not be 0 in result
-SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 10;
-
--- Case 2:
+-- Case:
 -- Index is created externally
 -- Vectors are deleted from the table
 -- CREATE INDEX is run on the table with external file
@@ -66,16 +53,3 @@ DELETE FROM sift_base1k WHERE id=777;
 CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
 -- This should not throw error, but the first result will not be 0 as vector 777 is deleted from the table
 SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
-
--- Case 3:
--- Index is created externally
--- Vectors updated
--- CREATE INDEX is run on the table with external file
-DROP TABLE sift_base1k CASCADE;
-\ir utils/sift1k_array.sql
-UPDATE  sift_base1k SET v=:'v1001' WHERE id=777;
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
--- The first row will not be 0 now as the vector under id=777 was updated to 1,1,1,1... but it was indexed with different vector
--- So the usearch index can not find 1,1,1,1,1.. vector in the index and wrong results will be returned
--- This is an expected behaviour for now
-SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 10;


### PR DESCRIPTION
## Description
- Added parameter `_experimental_index_path`
- If the `_experimental_index_path` will be defined we will load the index in `BuildIndex` function instead of doing table scan.
- Changed label creation code to take exactly 6 bytes from `ItemPointerData` struct, previously it might fill the last 2 bytes with garbage.
- Added tests with 2 index files to test the functionality