### PR TITLE
Save and load usearch options from index header page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build
 data
 .vscode/
 .devcontainer/
+.cache

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,8 +1,10 @@
 ARG VERSION=15
+ARG PGVECTOR_VERSION=0.4.4
 ARG IMAGE_TAG=$VERSION-bookworm
 
 FROM postgres:$IMAGE_TAG
 ARG VERSION
+ARG PGVECTOR_VERSION
 
 WORKDIR /lanterndb
 
@@ -13,7 +15,6 @@ RUN apt update \
        build-essential \
        cmake \
        postgresql-server-dev-$VERSION \
-       postgresql-$VERSION-pgvector \
        gdb \
        wget \
        python3-pip \
@@ -23,7 +24,12 @@ RUN apt update \
        git-all \
        tmux \
        clang-format \
-    && pip install libtmux --break-system-packages
+    && pip install libtmux --break-system-packages && \
+    # Install pgvector 0.4.4 (latest compatible version with LanternDB)
+    wget -O pgvector.tar.gz https://github.com/pgvector/pgvector/archive/refs/tags/v${PGVECTOR_VERSION}.tar.gz && \
+    tar xzf pgvector.tar.gz && \
+    cd pgvector-${PGVECTOR_VERSION} && \
+    make && make install
 
 COPY . .
 

--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -29,7 +29,14 @@ function setup_postgres() {
   apt update
   apt install -y postgresql-$PG_VERSION postgresql-server-dev-$PG_VERSION
   # Install pgvector
-  apt install -y postgresql-$PG_VERSION-pgvector
+  pushd /tmp
+    PGVECTOR_VERSION=0.4.4
+    wget -O pgvector.tar.gz https://github.com/pgvector/pgvector/archive/refs/tags/v${PGVECTOR_VERSION}.tar.gz
+    tar xzf pgvector.tar.gz
+    pushd pgvector-${PGVECTOR_VERSION}
+      make && make install
+    popd
+  popd
   # Fix pg_config (sometimes it points to wrong version)
   rm -f /usr/bin/pg_config && ln -s /usr/lib/postgresql/$PG_VERSION/bin/pg_config /usr/bin/pg_config
 }

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -53,8 +53,13 @@ then
     mkdir -p $TMP_ROOT/files
     echo "Downloading necessary files for tests..."
     pushd $TMP_ROOT/files
-       curl -sSo index-sift1k-cos.usearch https://storage.googleapis.com/lanterndata/lanterndb_binary_indexes/index-sift1k-cos.usearch
-       curl -sSo index-sift1k-l2.usearch https://storage.googleapis.com/lanterndata/lanterndb_binary_indexes/index-sift1k-l2.usearch
+       # Index file to test version compatibility
+       curl -sSo index-sift1k-l2-0.0.0.usearch https://storage.googleapis.com/lanterndata/lanterndb_binary_indexes/index-sift1k-l2-v2.usearch
+       # Actual index files
+       curl -sSo index-sift1k-cos.usearch https://storage.googleapis.com/lanterndata/lanterndb_binary_indexes/index-sift1k-cos-v3.usearch
+       curl -sSo index-sift1k-l2.usearch https://storage.googleapis.com/lanterndata/lanterndb_binary_indexes/index-sift1k-l2-v3.usearch
+       # Corrupted index file for test
+       tail -c +100 index-sift1k-l2.usearch > index-sift1k-l2-corrupted.usearch
     popd
     echo "Successfully downloaded all necessary test files"
 fi

--- a/src/hnsw/options.h
+++ b/src/hnsw/options.h
@@ -4,7 +4,7 @@
 
 #include <utils/relcache.h>  // Relation
 
-#include "external_index.h"
+#include "usearch.h"
 
 // todo:: add hnsw dynamic vector dimension constraints
 // based on vector element size

--- a/test/expected/hnsw_index_from_file.out
+++ b/test/expected/hnsw_index_from_file.out
@@ -11,20 +11,28 @@ CREATE TABLE IF NOT EXISTS sift_base1k (
     v REAL[]
 );
 COPY sift_base1k (v) FROM '/tmp/lanterndb/vector_datasets/sift_base1k_arrays.csv' WITH csv;
--- Validate error on invalid path
 \set ON_ERROR_STOP off
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/invalid-path');
+-- Validate error on invalid path
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/invalid-path');
 ERROR:  Invalid index file path 
+-- Validate error on incompatible version
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2-0.0.0.usearch');
+INFO:  done init usearch index
+ERROR:  Incompatible version of index file
+-- Validate error on invalid file
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2-corrupted.usearch');
+INFO:  done init usearch index
+ERROR:  Wrong MIME type!
 \set ON_ERROR_STOP on
 -- Validate that creating an index from file works
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
 INFO:  done init usearch index
 INFO:  done loading usearch index
 INFO:  done saving 1000 vectors
 SELECT * FROM ldb_get_indexes('sift_base1k');
-   indexname   |  size  |                                                                                              indexdef                                                                                              | total_index_size 
----------------+--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
- hnsw_l2_index | 720 kB | CREATE INDEX hnsw_l2_index ON public.sift_base1k USING hnsw (v) WITH (dims='128', m='16', ef='64', ef_construction='128', _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch') | 720 kB
+   indexname   |  size  |                                                                    indexdef                                                                    | total_index_size 
+---------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------
+ hnsw_l2_index | 720 kB | CREATE INDEX hnsw_l2_index ON public.sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch') | 720 kB
 (1 row)
 
 SET enable_seqscan = false;
@@ -39,7 +47,7 @@ EXPLAIN (COSTS FALSE) SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_
 
 SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
 INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+INFO:  starting scan with dimensions=128 M=16 efConstruction=64 ef=32
 INFO:  usearch index initialized
    round   
 -----------
@@ -62,7 +70,7 @@ INSERT INTO sift_base1k (id, v) VALUES
 SELECT v AS v1001 FROM sift_base1k WHERE id = 1001 \gset
 SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 10;
 INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+INFO:  starting scan with dimensions=128 M=16 efConstruction=64 ef=32
 INFO:  usearch index initialized
    round   
 -----------
@@ -87,14 +95,14 @@ CREATE TABLE IF NOT EXISTS sift_base1k (
 );
 COPY sift_base1k (v) FROM '/tmp/lanterndb/vector_datasets/sift_base1k_arrays.csv' WITH csv;
 -- Validate that creating an index from file works with cosine distance function
-CREATE INDEX hnsw_cos_index ON sift_base1k USING hnsw (v dist_cos_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-cos.usearch');
+CREATE INDEX hnsw_cos_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-cos.usearch');
 INFO:  done init usearch index
 INFO:  done loading usearch index
 INFO:  done saving 1000 vectors
 SELECT * FROM ldb_get_indexes('sift_base1k');
-   indexname    |  size  |                                                                                                     indexdef                                                                                                      | total_index_size 
-----------------+--------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------
- hnsw_cos_index | 720 kB | CREATE INDEX hnsw_cos_index ON public.sift_base1k USING hnsw (v dist_cos_ops) WITH (dims='128', m='16', ef='64', ef_construction='128', _experimental_index_path='/tmp/lanterndb/files/index-sift1k-cos.usearch') | 720 kB
+   indexname    |  size  |                                                                     indexdef                                                                     | total_index_size 
+----------------+--------+--------------------------------------------------------------------------------------------------------------------------------------------------+------------------
+ hnsw_cos_index | 720 kB | CREATE INDEX hnsw_cos_index ON public.sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-cos.usearch') | 720 kB
 (1 row)
 
 SELECT v AS v777 FROM sift_base1k WHERE id = 777 \gset
@@ -108,7 +116,7 @@ EXPLAIN (COSTS FALSE) SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_b
 
 SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
 INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+INFO:  starting scan with dimensions=128 M=16 efConstruction=64 ef=32
 INFO:  usearch index initialized
  round 
 -------
@@ -138,14 +146,14 @@ CREATE TABLE IF NOT EXISTS sift_base1k (
 );
 COPY sift_base1k (v) FROM '/tmp/lanterndb/vector_datasets/sift_base1k_arrays.csv' WITH csv;
 DELETE FROM sift_base1k WHERE id=777;
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
 INFO:  done init usearch index
 INFO:  done loading usearch index
 INFO:  done saving 1000 vectors
 -- This should not throw error, but the first result will not be 0 as vector 777 is deleted from the table
 SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
 INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+INFO:  starting scan with dimensions=128 M=16 efConstruction=64 ef=32
 INFO:  usearch index initialized
    round   
 -----------

--- a/test/expected/hnsw_todo.out
+++ b/test/expected/hnsw_todo.out
@@ -78,14 +78,14 @@ INSERT INTO sift_base1k (id, v) VALUES
 (1001, array_fill(1, ARRAY[128])),
 (1102, array_fill(2, ARRAY[128]));
 SELECT v AS v1001 FROM sift_base1k WHERE id = 1001 \gset
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
 INFO:  done init usearch index
 INFO:  done loading usearch index
 INFO:  done saving 1000 vectors
 -- The 1001 and 1002 vectors will be ignored in search, so the first row will not be 0 in result
 SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 1;
 INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+INFO:  starting scan with dimensions=128 M=16 efConstruction=64 ef=32
 INFO:  usearch index initialized
    round   
 -----------
@@ -104,7 +104,7 @@ CREATE TABLE IF NOT EXISTS sift_base1k (
 );
 COPY sift_base1k (v) FROM '/tmp/lanterndb/vector_datasets/sift_base1k_arrays.csv' WITH csv;
 UPDATE sift_base1k SET v=:'v1001' WHERE id=777;
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
 INFO:  done init usearch index
 INFO:  done loading usearch index
 INFO:  done saving 1000 vectors
@@ -113,10 +113,10 @@ INFO:  done saving 1000 vectors
 -- This is an expected behaviour for now
 SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 1;
 INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=16 efConstruction=128 ef=64
+INFO:  starting scan with dimensions=128 M=16 efConstruction=64 ef=32
 INFO:  usearch index initialized
    round   
 -----------
- 249285.00
+ 0.00
 (1 row)
 

--- a/test/sql/hnsw_index_from_file.sql
+++ b/test/sql/hnsw_index_from_file.sql
@@ -8,12 +8,16 @@
 -- Validate that index creation works with a small number of vectors
 \ir utils/sift1k_array.sql
 
--- Validate error on invalid path
 \set ON_ERROR_STOP off
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/invalid-path');
+-- Validate error on invalid path
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/invalid-path');
+-- Validate error on incompatible version
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2-0.0.0.usearch');
+-- Validate error on invalid file
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2-corrupted.usearch');
 \set ON_ERROR_STOP on
 -- Validate that creating an index from file works
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
 SELECT * FROM ldb_get_indexes('sift_base1k');
 
 SET enable_seqscan = false;
@@ -33,7 +37,7 @@ DROP TABLE sift_base1k CASCADE;
 \ir utils/sift1k_array.sql
 
 -- Validate that creating an index from file works with cosine distance function
-CREATE INDEX hnsw_cos_index ON sift_base1k USING hnsw (v dist_cos_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-cos.usearch');
+CREATE INDEX hnsw_cos_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-cos.usearch');
 SELECT * FROM ldb_get_indexes('sift_base1k');
 
 SELECT v AS v777 FROM sift_base1k WHERE id = 777 \gset
@@ -50,6 +54,6 @@ SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :
 DROP TABLE sift_base1k CASCADE;
 \ir utils/sift1k_array.sql
 DELETE FROM sift_base1k WHERE id=777;
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
 -- This should not throw error, but the first result will not be 0 as vector 777 is deleted from the table
 SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;

--- a/test/sql/hnsw_todo.sql
+++ b/test/sql/hnsw_todo.sql
@@ -56,7 +56,7 @@ INSERT INTO sift_base1k (id, v) VALUES
 (1001, array_fill(1, ARRAY[128])),
 (1102, array_fill(2, ARRAY[128]));
 SELECT v AS v1001 FROM sift_base1k WHERE id = 1001 \gset
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
 -- The 1001 and 1002 vectors will be ignored in search, so the first row will not be 0 in result
 SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 1;
 
@@ -67,7 +67,7 @@ SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <->
 DROP TABLE sift_base1k CASCADE;
 \ir utils/sift1k_array.sql
 UPDATE sift_base1k SET v=:'v1001' WHERE id=777;
-CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v dist_l2sq_ops) WITH (dims=128, M=16, ef=64, ef_construction=128, _experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
+CREATE INDEX hnsw_l2_index ON sift_base1k USING hnsw (v) WITH (_experimental_index_path='/tmp/lanterndb/files/index-sift1k-l2.usearch');
 -- The first row will not be 0 now as the vector under id=777 was updated to 1,1,1,1... but it was indexed with different vector
 -- So the usearch index can not find 1,1,1,1,1.. vector in the index and wrong results will be returned
 -- This is an expected behaviour for now


### PR DESCRIPTION
## Description
With this changes we will keep the necessary usearch options (`dimensions`, `ef`, `ef_construction`, `m`, `metric_kind`) in our index header when building index and in scans read the options from index header instead of index options.
Also we will add `ef` and `ef_construction` params in usearch index header, and make it reload the values when loaded from file as you can see in [this PR](https://github.com/Ngalstyan4/usearch/pull/8) . 

By doing this we can omit all the parameters when building index from file, as we will get the required values from the usearch header and save them in our index header to be used on table scans.

Currently the tests are failing, as the old versions of index files are being used, they need to be replaced in the bucket with newer versions.
