### PR TITLE
cleanup: get rid of unnecessary markbufferdirty and field

### DIFF
--- a/src/hnsw/external_index.c
+++ b/src/hnsw/external_index.c
@@ -85,7 +85,7 @@ int CreateBlockMapGroup(
         special->lastId = first_node_index + (blockmap_id + 1) * HNSW_BLOCKMAP_BLOCKS_PER_PAGE - 1;
         special->nextblockno = BufferGetBlockNumber(buf) + 1;
 
-        MarkBufferDirty(buf);
+        // GenericXLogFinish also calls MarkBufferDirty(buf)
         GenericXLogFinish(state);
         UnlockReleaseBuffer(buf);
         // GenericXLog allows registering up to 4 buffers at a time. So, we cannot set up large BlockMapGroups

--- a/src/hnsw/extra_dirtied.c
+++ b/src/hnsw/extra_dirtied.c
@@ -4,15 +4,14 @@
 
 #include <assert.h>
 
-ExtraDirtiedBufs *extra_dirtied_new(Relation index_rel)
+ExtraDirtiedBufs *extra_dirtied_new()
 {
     ExtraDirtiedBufs *ed = palloc0(sizeof(ExtraDirtiedBufs));
     assert(ed != NULL);
-    ed->index_rel = index_rel;
-    ed->EXTRA_DIRTIED_BLOCKNO = palloc0(sizeof(BlockNumber) * LDB_HNSW_INSERT_MAX_EXTRA_DIRTIED_BUFS);
-    ed->EXTRA_DIRTIED_BUF = palloc0(sizeof(Buffer) * LDB_HNSW_INSERT_MAX_EXTRA_DIRTIED_BUFS);
-    ed->EXTRA_DIRTIED_PAGE = palloc0(sizeof(Page) * LDB_HNSW_INSERT_MAX_EXTRA_DIRTIED_BUFS);
-    ed->EXTRA_DIRTIED_SIZE = 0;
+    ed->extra_dirtied_blockno = palloc0(sizeof(BlockNumber) * LDB_HNSW_INSERT_MAX_EXTRA_DIRTIED_BUFS);
+    ed->extra_dirtied_buf = palloc0(sizeof(Buffer) * LDB_HNSW_INSERT_MAX_EXTRA_DIRTIED_BUFS);
+    ed->extra_dirtied_page = palloc0(sizeof(Page) * LDB_HNSW_INSERT_MAX_EXTRA_DIRTIED_BUFS);
+    ed->extra_dirtied_size = 0;
     return ed;
 }
 
@@ -24,20 +23,20 @@ void extra_dirtied_add(ExtraDirtiedBufs *ed, BlockNumber blockno, Buffer buf, Pa
     // todo:: check as invariant that the page is locked at and is under WAL
     // currently, it may not always be under WAL which should be fixed
     
-    assert(ed->EXTRA_DIRTIED_SIZE + 1 < LDB_HNSW_INSERT_MAX_EXTRA_DIRTIED_BUFS);
-    ed->EXTRA_DIRTIED_PAGE[ ed->EXTRA_DIRTIED_SIZE++ ] = page;
-    ed->EXTRA_DIRTIED_BUF[ ed->EXTRA_DIRTIED_SIZE - 1 ] = buf;
-    ed->EXTRA_DIRTIED_BLOCKNO[ ed->EXTRA_DIRTIED_SIZE - 1 ] = blockno;
+    assert(ed->extra_dirtied_size + 1 < LDB_HNSW_INSERT_MAX_EXTRA_DIRTIED_BUFS);
+    ed->extra_dirtied_page[ ed->extra_dirtied_size++ ] = page;
+    ed->extra_dirtied_buf[ ed->extra_dirtied_size - 1 ] = buf;
+    ed->extra_dirtied_blockno[ ed->extra_dirtied_size - 1 ] = blockno;
 }
 
 Page extra_dirtied_get(ExtraDirtiedBufs *ed, BlockNumber blockno, Buffer *buf)
 {
-    for(int i = 0; i < ed->EXTRA_DIRTIED_SIZE; i++) {
-        if(ed->EXTRA_DIRTIED_BLOCKNO[ i ] == blockno) {
+    for(int i = 0; i < ed->extra_dirtied_size; i++) {
+        if(ed->extra_dirtied_blockno[ i ] == blockno) {
             if(buf != NULL) {
-                *buf = ed->EXTRA_DIRTIED_BUF[ i ];
+                *buf = ed->extra_dirtied_buf[ i ];
             }
-            return ed->EXTRA_DIRTIED_PAGE[ i ];
+            return ed->extra_dirtied_page[ i ];
         }
     }
     return NULL;
@@ -45,27 +44,27 @@ Page extra_dirtied_get(ExtraDirtiedBufs *ed, BlockNumber blockno, Buffer *buf)
 
 void extra_dirtied_release_all(ExtraDirtiedBufs *ed)
 {
-    for(int i = 0; i < ed->EXTRA_DIRTIED_SIZE; i++) {
-        assert(BufferIsValid(ed->EXTRA_DIRTIED_BUF[ i ]));
+    for(int i = 0; i < ed->extra_dirtied_size; i++) {
+        assert(BufferIsValid(ed->extra_dirtied_buf[ i ]));
         // header is not considered extra. we know we should not have dirtied it
         // sanity check callees that manimulate extra_dirtied did not violate this
-        assert(ed->EXTRA_DIRTIED_BLOCKNO[ i ] != 0);
-        MarkBufferDirty(ed->EXTRA_DIRTIED_BUF[ i ]);
-        UnlockReleaseBuffer(ed->EXTRA_DIRTIED_BUF[ i ]);
+        assert(ed->extra_dirtied_blockno[ i ] != 0);
+        MarkBufferDirty(ed->extra_dirtied_buf[ i ]);
+        UnlockReleaseBuffer(ed->extra_dirtied_buf[ i ]);
     }
-    ed->EXTRA_DIRTIED_SIZE = 0;
+    ed->extra_dirtied_size = 0;
 }
 
 void extra_dirtied_free(ExtraDirtiedBufs *ed)
 {
-    if(ed->EXTRA_DIRTIED_SIZE != 0) {
+    if(ed->extra_dirtied_size != 0) {
         elog(WARNING, "extra dirtied size is not 0. Was something aborted?");
         extra_dirtied_release_all(ed);
     }
 
-    ed->EXTRA_DIRTIED_SIZE = 0;
-    pfree(ed->EXTRA_DIRTIED_BUF);
-    pfree(ed->EXTRA_DIRTIED_PAGE);
-    pfree(ed->EXTRA_DIRTIED_BLOCKNO);
+    ed->extra_dirtied_size = 0;
+    pfree(ed->extra_dirtied_buf);
+    pfree(ed->extra_dirtied_page);
+    pfree(ed->extra_dirtied_blockno);
     pfree(ed);
 }

--- a/src/hnsw/extra_dirtied.h
+++ b/src/hnsw/extra_dirtied.h
@@ -14,14 +14,13 @@
 
 typedef struct
 {
-    Relation     index_rel;
-    BlockNumber* EXTRA_DIRTIED_BLOCKNO;
-    Buffer*      EXTRA_DIRTIED_BUF;
-    Page*        EXTRA_DIRTIED_PAGE;
-    int          EXTRA_DIRTIED_SIZE;
+    BlockNumber* extra_dirtied_blockno;
+    Buffer*      extra_dirtied_buf;
+    Page*        extra_dirtied_page;
+    int          extra_dirtied_size;
 } ExtraDirtiedBufs;
 
-ExtraDirtiedBufs* extra_dirtied_new(Relation index_rel);
+ExtraDirtiedBufs* extra_dirtied_new();
 // Page extra_dirtied_add(ExtraDirtiedBufs *ed, BlockNumber blockno);
 void extra_dirtied_add(ExtraDirtiedBufs* ed, BlockNumber blockno, Buffer buf, Page page);
 Page extra_dirtied_get(ExtraDirtiedBufs* ed, BlockNumber blockno, Buffer* out_buf);

--- a/src/hnsw/insert.c
+++ b/src/hnsw/insert.c
@@ -157,6 +157,7 @@ bool ldb_aminsert(Relation         index,
     // we only release the header buffer AFTER inserting is finished to make sure nobody else changes the block
     // structure. todo:: critical section here can definitely be shortened
     {
+        // GenericXLogFinish also calls MarkBufferDirty(buf)
         XLogRecPtr ptr = GenericXLogFinish(state);
         assert(ptr != InvalidXLogRecPtr);
         LDB_UNUSED(ptr);
@@ -171,7 +172,7 @@ bool ldb_aminsert(Relation         index,
 
     // unlock the header page
     assert(BufferIsValid(hdr_buf));
-    MarkBufferDirty(hdr_buf);
+    // GenericXLogFinish already marks hdr_buf as dirty
     UnlockReleaseBuffer(hdr_buf);
 
     ldb_wal_retriever_area_fini(insertstate->retriever_ctx);

--- a/src/hnsw/retriever.c
+++ b/src/hnsw/retriever.c
@@ -19,7 +19,7 @@ RetrieverCtx *ldb_wal_retriever_area_init(Relation index_rel, HnswIndexHeaderPag
     RetrieverCtx *ctx = palloc0(sizeof(RetrieverCtx));
     ctx->index_rel = index_rel;
     ctx->header_page_under_wal = header_page_under_wal;
-    ctx->extra_dirted = extra_dirtied_new(index_rel);
+    ctx->extra_dirted = extra_dirtied_new();
     fa_cache_init(&ctx->fa_cache);
 
     dlist_init(&ctx->takenbuffers);


### PR DESCRIPTION
This commit does 3 things:
- Get rid of index_rel from ExtraDirtiedBufs as it's not used
- Rename ExtraDirtiedBufs fields to be lower case instead of upper case. Based on Narek, they were upper case before to indicate they could only be touched/modified once across all threads (i.e. the variables were global)
- Get rid of unnecessary MarkBufferDirty. In cases where a buffer is tracked by xlog, GenericXLogFinish will call MarkBufferDirty so we don't need to call it ourselves.  [Source](https://github.com/postgres/postgres/blob/master/src/backend/access/transam/generic_xlog.c#L413)