### PR TITLE
Fix test runner for OS X, fix checking pgvector in tests

### DIFF
--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -60,7 +60,7 @@ then
 fi
 
 # Check if pgvector is available
-pgvector_installed=$($PSQL -U $DB_USER -c "SELECT 1 FROM pg_available_extensions WHERE name = 'vector'" -tA)
+pgvector_installed=$($PSQL -U $DB_USER -d postgres -c "SELECT 1 FROM pg_available_extensions WHERE name = 'vector'" -tA)
 
 # Generate schedule.txt
 rm -rf $TMP_OUTDIR/schedule.txt

--- a/test/expected/hnsw_cost_estimate.out
+++ b/test/expected/hnsw_cost_estimate.out
@@ -10,7 +10,7 @@ CREATE INDEX hnsw_idx ON sift_base10k_0 USING hnsw (v dist_l2sq_ops) WITH (M=2, 
 INFO:  done init usearch index
 INFO:  inserted 0 elements
 INFO:  done saving 0 vectors
-EXPLAIN ANALYZE SELECT * FROM sift_base10k_0 order by v <-> '{1, 2}'
+EXPLAIN (ANALYZE,TIMING FALSE) SELECT * FROM sift_base10k_0 order by v <-> '{1, 2}'
 LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
@@ -23,8 +23,8 @@ INFO:  began scanning with 0 keys and 1 orderbys
 INFO:  starting scan with dimensions=2 M=2 efConstruction=10 ef=2
 INFO:  usearch index initialized
 DEBUG:  LANTERN querying index for 10 elements
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
+                                                    QUERY PLAN                                                    
+------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..0.47 rows=10 width=40) (actual rows=0 loops=1)
    ->  Index Scan using hnsw_idx on sift_base10k_0  (cost=0.00..60.10 rows=1270 width=40) (actual rows=0 loops=1)
          Order By: (v <-> '{1,2}'::real[])
@@ -43,7 +43,7 @@ INFO:  done init usearch index
 INFO:  inserted 10000 elements
 INFO:  done saving 10000 vectors
 SELECT V AS v4444  FROM sift_base10k_1 WHERE id = 4444 \gset
-EXPLAIN ANALYZE SELECT * FROM sift_base10k_1 order by v <-> :'v4444'
+EXPLAIN (ANALYZE,TIMING FALSE) SELECT * FROM sift_base10k_1 order by v <-> :'v4444'
 LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
@@ -76,7 +76,7 @@ INFO:  done init usearch index
 INFO:  inserted 10000 elements
 INFO:  done saving 10000 vectors
 SELECT V AS v4444  FROM sift_base10k_2 WHERE id = 4444 \gset
-EXPLAIN ANALYZE SELECT * FROM sift_base10k_2 order by v <-> :'v4444'
+EXPLAIN (ANALYZE,TIMING FALSE) SELECT * FROM sift_base10k_2 order by v <-> :'v4444'
 LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------
@@ -109,7 +109,7 @@ INFO:  done init usearch index
 INFO:  inserted 10000 elements
 INFO:  done saving 10000 vectors
 SELECT V AS v4444  FROM sift_base10k_3 WHERE id = 4444 \gset
-EXPLAIN ANALYZE SELECT * FROM sift_base10k_3 order by v <-> :'v4444'
+EXPLAIN (ANALYZE,TIMING FALSE) SELECT * FROM sift_base10k_3 order by v <-> :'v4444'
 LIMIT 10;
 DEBUG:  LANTERN - Query cost estimator
 DEBUG:  LANTERN - ---------------------

--- a/test/expected/hnsw_insert.out
+++ b/test/expected/hnsw_insert.out
@@ -51,7 +51,6 @@ ERROR:  Wrong number of dimensions: 4 instead of 3 expected
 \set ON_ERROR_STOP on
 -- Verify that the index works with the inserted vectors
 SELECT
-    id,
     ROUND(l2sq_dist(v, '{0,0,0}')::numeric, 2)
 FROM
     small_world
@@ -60,17 +59,17 @@ ORDER BY
 INFO:  began scanning with 0 keys and 1 orderbys
 INFO:  starting scan with dimensions=3 M=16 efConstruction=128 ef=64
 INFO:  usearch index initialized
- id  | round 
------+-------
- 000 |  0.00
- 001 |  1.00
- 010 |  1.00
- 100 |  1.00
- 011 |  2.00
- 101 |  2.00
- 110 |  2.00
- 111 |  3.00
-     |  6.00
+ round 
+-------
+  0.00
+  1.00
+  1.00
+  1.00
+  2.00
+  2.00
+  2.00
+  3.00
+  6.00
 (9 rows)
 
 -- Ensure the index size remains consistent after inserts
@@ -83,7 +82,6 @@ SELECT * from ldb_get_indexes('small_world');
 -- Ensure the query plan remains consistent after inserts
 EXPLAIN (COSTS FALSE)
 SELECT
-    id,
     ROUND(l2sq_dist(v, '{0,0,0}')::numeric, 2)
 FROM
     small_world

--- a/test/sql/hnsw_cost_estimate.sql
+++ b/test/sql/hnsw_cost_estimate.sql
@@ -9,7 +9,7 @@ CREATE TABLE sift_base10k_0 (
      v real[128]
 );
 CREATE INDEX hnsw_idx ON sift_base10k_0 USING hnsw (v dist_l2sq_ops) WITH (M=2, ef_construction=10, ef=2, dims=2);
-EXPLAIN ANALYZE SELECT * FROM sift_base10k_0 order by v <-> '{1, 2}'
+EXPLAIN (ANALYZE,TIMING FALSE) SELECT * FROM sift_base10k_0 order by v <-> '{1, 2}'
 LIMIT 10;
 DROP INDEX hnsw_idx;
 
@@ -22,7 +22,7 @@ CREATE TABLE sift_base10k_1 (
 \copy sift_base10k_1 (v) FROM '/tmp/lanterndb/vector_datasets/siftsmall_base_arrays.csv' with csv;
 CREATE INDEX hnsw_idx ON sift_base10k_1 USING hnsw (v dist_l2sq_ops) WITH (M=2, ef_construction=10, ef=4, dims=128);
 SELECT V AS v4444  FROM sift_base10k_1 WHERE id = 4444 \gset
-EXPLAIN ANALYZE SELECT * FROM sift_base10k_1 order by v <-> :'v4444'
+EXPLAIN (ANALYZE,TIMING FALSE) SELECT * FROM sift_base10k_1 order by v <-> :'v4444'
 LIMIT 10;
 DROP INDEX hnsw_idx;
 
@@ -35,7 +35,7 @@ CREATE TABLE sift_base10k_2 (
 \copy sift_base10k_2 (v) FROM '/tmp/lanterndb/vector_datasets/siftsmall_base_arrays.csv' with csv;
 CREATE INDEX hnsw_idx ON sift_base10k_2 USING hnsw (v dist_l2sq_ops) WITH (M=20, ef_construction=10, ef=4, dims=128);
 SELECT V AS v4444  FROM sift_base10k_2 WHERE id = 4444 \gset
-EXPLAIN ANALYZE SELECT * FROM sift_base10k_2 order by v <-> :'v4444'
+EXPLAIN (ANALYZE,TIMING FALSE) SELECT * FROM sift_base10k_2 order by v <-> :'v4444'
 LIMIT 10;
 DROP INDEX hnsw_idx;
 
@@ -48,6 +48,6 @@ CREATE TABLE sift_base10k_3 (
 \copy sift_base10k_3 (v) FROM '/tmp/lanterndb/vector_datasets/siftsmall_base_arrays.csv' with csv;
 CREATE INDEX hnsw_idx ON sift_base10k_3 USING hnsw (v dist_l2sq_ops) WITH (M=20, ef_construction=10, ef=16, dims=128);
 SELECT V AS v4444  FROM sift_base10k_3 WHERE id = 4444 \gset
-EXPLAIN ANALYZE SELECT * FROM sift_base10k_3 order by v <-> :'v4444'
+EXPLAIN (ANALYZE,TIMING FALSE) SELECT * FROM sift_base10k_3 order by v <-> :'v4444'
 LIMIT 10;
 DROP INDEX hnsw_idx;

--- a/test/sql/hnsw_insert.sql
+++ b/test/sql/hnsw_insert.sql
@@ -40,7 +40,6 @@ INSERT INTO small_world (v) VALUES ('{4,4,4,4}');
 
 -- Verify that the index works with the inserted vectors
 SELECT
-    id,
     ROUND(l2sq_dist(v, '{0,0,0}')::numeric, 2)
 FROM
     small_world
@@ -53,7 +52,6 @@ SELECT * from ldb_get_indexes('small_world');
 -- Ensure the query plan remains consistent after inserts
 EXPLAIN (COSTS FALSE)
 SELECT
-    id,
     ROUND(l2sq_dist(v, '{0,0,0}')::numeric, 2)
 FROM
     small_world

--- a/test/test_runner.sh
+++ b/test/test_runner.sh
@@ -46,4 +46,4 @@ psql -U ${DB_USER} \
           grep -Gv '^ Planning Time:' | \
           grep -Gv '^ Execution Time:' | \
           # Only print debug messages followed by LANTERN
-          grep -vP 'DEBUG:(?!.*LANTERN)'
+          perl -nle'print if !m{DEBUG:(?!.*LANTERN)}'


### PR DESCRIPTION
Changed `grep -P` to `perl` as `-P` option is no longer supported on OS X. [reference](https://stackoverflow.com/questions/16658333/grep-p-no-longer-works-how-can-i-rewrite-my-searches)  

Changed the database name when checking if `pgvector` is installed to `postgres`, as now it defaults to current os username and it may fail.

Removed timing from explains, removed ids from select as if 2 vectors would have the same distance the order might be different based on machine and test might fail