### PR TITLE
Reduce elog overhead on fastpath

### DIFF
--- a/test/expected/hnsw_correct.out
+++ b/test/expected/hnsw_correct.out
@@ -29,9 +29,6 @@ SELECT
     l2sq_dist(v, '{0,0}') AS dist
 FROM
     small_world;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=2 M=4 efConstruction=128 ef=64
-INFO:  usearch index initialized
 -- Validate that the results are same with and without the index (should be empty)
 SELECT
     a.row_num,

--- a/test/expected/hnsw_cost_estimate.out
+++ b/test/expected/hnsw_cost_estimate.out
@@ -19,10 +19,6 @@ DEBUG:  LANTERN - Selectivity: 1.000000
 DEBUG:  LANTERN - Num pages: 1.000000
 DEBUG:  LANTERN - Num tuples: 30.000000
 DEBUG:  LANTERN - ---------------------
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=2 M=2 efConstruction=10 ef=2
-INFO:  usearch index initialized
-DEBUG:  LANTERN querying index for 10 elements
                                                     QUERY PLAN                                                    
 ------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..0.47 rows=10 width=40) (actual rows=0 loops=1)
@@ -52,10 +48,6 @@ DEBUG:  LANTERN - Selectivity: 1.000000
 DEBUG:  LANTERN - Num pages: 4.000000
 DEBUG:  LANTERN - Num tuples: 46.000000
 DEBUG:  LANTERN - ---------------------
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=2 efConstruction=10 ef=4
-INFO:  usearch index initialized
-DEBUG:  LANTERN querying index for 10 elements
                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                           
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..3.00 rows=10 width=40) (actual rows=10 loops=1)
@@ -85,10 +77,6 @@ DEBUG:  LANTERN - Selectivity: 1.000000
 DEBUG:  LANTERN - Num pages: 71.000000
 DEBUG:  LANTERN - Num tuples: 773.000000
 DEBUG:  LANTERN - ---------------------
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=20 efConstruction=10 ef=4
-INFO:  usearch index initialized
-DEBUG:  LANTERN querying index for 10 elements
                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                           
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..3.27 rows=10 width=40) (actual rows=10 loops=1)
@@ -118,10 +106,6 @@ DEBUG:  LANTERN - Selectivity: 1.000000
 DEBUG:  LANTERN - Num pages: 226.000000
 DEBUG:  LANTERN - Num tuples: 2465.000000
 DEBUG:  LANTERN - ---------------------
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=20 efConstruction=10 ef=16
-INFO:  usearch index initialized
-DEBUG:  LANTERN querying index for 10 elements
                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                           
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=0.00..3.91 rows=10 width=40) (actual rows=10 loops=1)

--- a/test/expected/hnsw_dist_func.out
+++ b/test/expected/hnsw_dist_func.out
@@ -37,9 +37,6 @@ INSERT INTO small_world_ham SELECT id, v FROM small_world;
 SET enable_seqscan = false;
 -- Verify that the distance functions work (check distances)
 SELECT ROUND(l2sq_dist(v, '{0,1,0}')::numeric, 2) FROM small_world_l2 ORDER BY v <-> '{0,1,0}';
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=16 efConstruction=128 ef=64
-INFO:  usearch index initialized
  round 
 -------
   0.00
@@ -53,9 +50,6 @@ INFO:  usearch index initialized
 (8 rows)
 
 SELECT ROUND(cos_dist(v, '{0,1,0}')::numeric, 2) FROM small_world_cos ORDER BY v <-> '{0,1,0}';
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=16 efConstruction=128 ef=64
-INFO:  usearch index initialized
  round 
 -------
   0.00
@@ -69,9 +63,6 @@ INFO:  usearch index initialized
 (8 rows)
 
 SELECT ROUND(hamming_dist(v, '{0,1,0}')::numeric, 2) FROM small_world_ham ORDER BY v <-> '{0,1,0}';
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=16 efConstruction=128 ef=64
-INFO:  usearch index initialized
  round 
 -------
   0.00
@@ -137,19 +128,10 @@ EXPLAIN SELECT id FROM small_world_ham ORDER BY v <-> '{0,1,0}';
 \set ON_ERROR_STOP off
 -- Expect errors due to mismatching vector dimensions
 SELECT 1 FROM small_world_l2 ORDER BY v <-> '{0,1,0,1}' LIMIT 1;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=16 efConstruction=128 ef=64
-INFO:  usearch index initialized
 ERROR:  Expected real array with dimension 3, got 4
 SELECT 1 FROM small_world_cos ORDER BY v <-> '{0,1,0,1}' LIMIT 1;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=16 efConstruction=128 ef=64
-INFO:  usearch index initialized
 ERROR:  Expected real array with dimension 3, got 4
 SELECT 1 FROM small_world_ham ORDER BY v <-> '{0,1,0,1}' LIMIT 1;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=16 efConstruction=128 ef=64
-INFO:  usearch index initialized
 ERROR:  Expected int array with dimension 3, got 4
 SELECT l2sq_dist('{1,1}', '{0,1,0}');
 ERROR:  expected equally sized arrays but got arrays with dimensions 2 and 3

--- a/test/expected/hnsw_index_from_file.out
+++ b/test/expected/hnsw_index_from_file.out
@@ -46,9 +46,6 @@ EXPLAIN (COSTS FALSE) SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_
 (3 rows)
 
 SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=16 efConstruction=64 ef=32
-INFO:  usearch index initialized
    round   
 -----------
       0.00
@@ -69,9 +66,6 @@ INSERT INTO sift_base1k (id, v) VALUES
 (1002, array_fill(2, ARRAY[128]));
 SELECT v AS v1001 FROM sift_base1k WHERE id = 1001 \gset
 SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 10;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=16 efConstruction=64 ef=32
-INFO:  usearch index initialized
    round   
 -----------
       0.00
@@ -115,9 +109,6 @@ EXPLAIN (COSTS FALSE) SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_b
 (3 rows)
 
 SELECT ROUND(cos_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=16 efConstruction=64 ef=32
-INFO:  usearch index initialized
  round 
 -------
   0.00
@@ -152,9 +143,6 @@ INFO:  done loading usearch index
 INFO:  done saving 1000 vectors
 -- This should not throw error, but the first result will not be 0 as vector 777 is deleted from the table
 SELECT ROUND(l2sq_dist(v, :'v777')::numeric, 2) FROM sift_base1k order by v <-> :'v777' LIMIT 10;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=16 efConstruction=64 ef=32
-INFO:  usearch index initialized
    round   
 -----------
   98486.00

--- a/test/expected/hnsw_insert.out
+++ b/test/expected/hnsw_insert.out
@@ -56,9 +56,6 @@ FROM
     small_world
 ORDER BY
     v <-> '{0,0,0}';
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=16 efConstruction=128 ef=64
-INFO:  usearch index initialized
  round 
 -------
   0.00

--- a/test/expected/hnsw_select.out
+++ b/test/expected/hnsw_select.out
@@ -88,10 +88,6 @@ DEBUG:  LANTERN - Selectivity: 1.000000
 DEBUG:  LANTERN - Num pages: 1.000000
 DEBUG:  LANTERN - Num tuples: 2.000000
 DEBUG:  LANTERN - ---------------------
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=5 efConstruction=20 ef=20
-INFO:  usearch index initialized
-DEBUG:  LANTERN querying index for 10 elements
  count 
 -------
      3
@@ -107,10 +103,6 @@ DEBUG:  LANTERN - Selectivity: 1.000000
 DEBUG:  LANTERN - Num pages: 1.000000
 DEBUG:  LANTERN - Num tuples: 2.000000
 DEBUG:  LANTERN - ---------------------
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=5 efConstruction=20 ef=20
-INFO:  usearch index initialized
-DEBUG:  LANTERN querying index for 10 elements
  count 
 -------
      8
@@ -128,10 +120,6 @@ DEBUG:  LANTERN - Selectivity: 1.000000
 DEBUG:  LANTERN - Num pages: 1.000000
 DEBUG:  LANTERN - Num tuples: 2.000000
 DEBUG:  LANTERN - ---------------------
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=5 efConstruction=20 ef=20
-INFO:  usearch index initialized
-DEBUG:  LANTERN querying index for 4 elements
  count 
 -------
      3
@@ -147,11 +135,6 @@ DEBUG:  LANTERN - Selectivity: 1.000000
 DEBUG:  LANTERN - Num pages: 1.000000
 DEBUG:  LANTERN - Num tuples: 2.000000
 DEBUG:  LANTERN - ---------------------
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=5 efConstruction=20 ef=20
-INFO:  usearch index initialized
-DEBUG:  LANTERN querying index for 4 elements
-DEBUG:  LANTERN - querying index for 8 elements
  count 
 -------
      8

--- a/test/expected/hnsw_todo.out
+++ b/test/expected/hnsw_todo.out
@@ -40,9 +40,6 @@ INFO:  done init usearch index
 INFO:  inserted 4 elements
 INFO:  done saving 4 vectors
 SELECT ROUND(hamming_dist(v, '{0,0}')::numeric, 2) FROM small_world_ham ORDER BY v <-> '{0,0}';
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=2 M=16 efConstruction=128 ef=64
-INFO:  usearch index initialized
  round 
 -------
   0.00
@@ -76,9 +73,6 @@ INFO:  done loading usearch index
 INFO:  done saving 1000 vectors
 -- The 1001 and 1002 vectors will be ignored in search, so the first row will not be 0 in result
 SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 1;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=16 efConstruction=64 ef=32
-INFO:  usearch index initialized
    round   
 -----------
  249285.00
@@ -104,9 +98,6 @@ INFO:  done saving 1000 vectors
 -- So the usearch index can not find 1,1,1,1,1.. vector in the index and wrong results will be returned
 -- This is an expected behaviour for now
 SELECT ROUND(l2sq_dist(v, :'v1001')::numeric, 2) FROM sift_base1k order by v <-> :'v1001' LIMIT 1;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=128 M=16 efConstruction=64 ef=32
-INFO:  usearch index initialized
    round   
 -----------
  249285.00

--- a/test/expected/hnsw_vector.out
+++ b/test/expected/hnsw_vector.out
@@ -78,9 +78,6 @@ INSERT INTO small_world (v) VALUES (NULL);
 -- Distance functions
 SELECT id, ROUND(l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=5 efConstruction=20 ef=20
-INFO:  usearch index initialized
  id  | dist 
 -----+------
  010 | 0.00
@@ -103,9 +100,6 @@ FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
 
 SELECT id, ROUND(vector_l2sq_dist(v, '[0,1,0]'::VECTOR)::numeric, 2) as dist
 FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=5 efConstruction=20 ef=20
-INFO:  usearch index initialized
  id  | dist 
 -----+------
  010 | 0.00
@@ -171,10 +165,6 @@ DEBUG:  LANTERN - Selectivity: 1.000000
 DEBUG:  LANTERN - Num pages: 1.000000
 DEBUG:  LANTERN - Num tuples: 2.000000
 DEBUG:  LANTERN - ---------------------
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=5 efConstruction=20 ef=20
-INFO:  usearch index initialized
-DEBUG:  LANTERN querying index for 4 elements
  count 
 -------
      3
@@ -190,12 +180,6 @@ DEBUG:  LANTERN - Selectivity: 1.000000
 DEBUG:  LANTERN - Num pages: 1.000000
 DEBUG:  LANTERN - Num tuples: 2.000000
 DEBUG:  LANTERN - ---------------------
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=5 efConstruction=20 ef=20
-INFO:  usearch index initialized
-DEBUG:  LANTERN querying index for 4 elements
-DEBUG:  LANTERN - querying index for 8 elements
-DEBUG:  LANTERN - querying index for 16 elements
  count 
 -------
      9
@@ -208,9 +192,6 @@ SELECT ARRAY[1,2,3] <-> ARRAY[3,2,1];
 ERROR:  Operator <-> has no standalone meaning and is reserved for use in vector index lookups only
 -- Expect error due to mismatching vector dimensions
 SELECT 1 FROM small_world ORDER BY v <-> '[0,1,0,1]' LIMIT 1;
-INFO:  began scanning with 0 keys and 1 orderbys
-INFO:  starting scan with dimensions=3 M=5 efConstruction=20 ef=20
-INFO:  usearch index initialized
 ERROR:  Expected vector with dimension 3, got 4
 SELECT vector_l2sq_dist('[1,1]'::vector, '[0,1,0]'::vector);
 ERROR:  expected equally sized vectors but got vectors with dimensions 2 and 3


### PR DESCRIPTION
Should be merged now.
- [ ] ~Add a CmakeLists option for defining `LANTERNDB_DEBUG_LOGS`~
- [ ] ~Build LanternDB with `LANTERNDB_DEBUG_LOGS` in ci/cd for tests~
- [ ] ~Separate out tests that need `LANTERNDB_DEBUG_LOGS` into one file (This will make sure that if users run tests locally, without enabling this flag on their release branch, tests only in one file will fail)~

