### PR TITLE
Enable codecov check only for prs

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,4 +6,7 @@ comment: # this is a top-level key
   require_head: true # [true :: must have a head report to post]
 coverage:
   status:
+    project:
+      default:
+        only_pulls: true
     patch: off


### PR DESCRIPTION
This PR will change the codecov default behaviour to run only on pull requests, so we won't have the failure checkmark on main branch in case of codecov failure