### PR TITLE
Add pgvector 0.5.0+ vector type compatibility

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 ARG VERSION=15
-ARG PGVECTOR_VERSION=0.4.4
+ARG PGVECTOR_VERSION=0.5.0
 ARG IMAGE_TAG=$VERSION-bookworm
 
 FROM postgres:$IMAGE_TAG
@@ -25,7 +25,6 @@ RUN apt update \
        tmux \
        clang-format \
     && pip install libtmux --break-system-packages && \
-    # Install pgvector 0.4.4 (latest compatible version with LanternDB)
     wget -O pgvector.tar.gz https://github.com/pgvector/pgvector/archive/refs/tags/v${PGVECTOR_VERSION}.tar.gz && \
     tar xzf pgvector.tar.gz && \
     cd pgvector-${PGVECTOR_VERSION} && \

--- a/ci/scripts/build-linux.sh
+++ b/ci/scripts/build-linux.sh
@@ -30,7 +30,7 @@ function setup_postgres() {
   apt install -y postgresql-$PG_VERSION postgresql-server-dev-$PG_VERSION
   # Install pgvector
   pushd /tmp
-    PGVECTOR_VERSION=0.4.4
+    PGVECTOR_VERSION=0.5.0
     wget -O pgvector.tar.gz https://github.com/pgvector/pgvector/archive/refs/tags/v${PGVECTOR_VERSION}.tar.gz
     tar xzf pgvector.tar.gz
     pushd pgvector-${PGVECTOR_VERSION}

--- a/src/hnsw.c
+++ b/src/hnsw.c
@@ -89,8 +89,8 @@ static uint64 estimate_number_tuples_accessed(Oid index_relation, double num_tup
     int M, ef;
     {  // index_rel scope
         Relation index_rel = relation_open(index_relation, AccessShareLock);
-        M = HnswGetM(index_rel);
-        ef = HnswGetEf(index_rel);
+        M = ldb_HnswGetM(index_rel);
+        ef = ldb_HnswGetEf(index_rel);
         relation_close(index_rel, AccessShareLock);
     }
 

--- a/src/hnsw/build.c
+++ b/src/hnsw/build.c
@@ -175,13 +175,13 @@ int GetHnswIndexDimensions(Relation index)
     // check if column is type of real[] or integer[]
     if(columnType == REAL_ARRAY || columnType == INT_ARRAY) {
         // The dimension in options is not set if the dimension is inferred so we need to actually check the key
-        int opt_dim = HnswGetDims(index);
+        int opt_dim = ldb_HnswGetDims(index);
         if(opt_dim == HNSW_DEFAULT_DIMS) {
             // If the option's still the default it needs to be updated to match what was inferred
             // todo: is there a way to do this earlier? (rd_options is null in BuildInit)
-            Relation     heap;
-            HnswOptions *opts;
-            int          attrNum;
+            Relation         heap;
+            ldb_HnswOptions *opts;
+            int              attrNum;
 
             assert(index->rd_index->indnatts == 1);
             attrNum = index->rd_index->indkey.values[ 0 ];
@@ -191,7 +191,7 @@ int GetHnswIndexDimensions(Relation index)
             heap = table_open(index->rd_index->indrelid, AccessShareLock);
 #endif
             opt_dim = GetArrayLengthFromHeap(heap, attrNum);
-            opts = (HnswOptions *)index->rd_options;
+            opts = (ldb_HnswOptions *)index->rd_options;
             if(opts != NULL) {
                 opts->dims = opt_dim;
             }
@@ -256,7 +256,7 @@ static void InitBuildState(HnswBuildState *buildstate, Relation heap, Relation i
     buildstate->indexInfo = indexInfo;
     buildstate->columnType = GetIndexColumnType(index);
     buildstate->dimensions = GetHnswIndexDimensions(index);
-    buildstate->index_file_path = HnswGetIndexFilePath(index);
+    buildstate->index_file_path = ldb_HnswGetIndexFilePath(index);
 
     // If a dimension wasn't specified try to infer it
     if(buildstate->dimensions < 1) {

--- a/src/hnsw/options.c
+++ b/src/hnsw/options.c
@@ -35,37 +35,37 @@ static relopt_kind ldb_hnsw_index_withopts;
 
 int ldb_hnsw_init_k;
 
-int HnswGetDims(Relation index)
+int ldb_HnswGetDims(Relation index)
 {
-    HnswOptions *opts = (HnswOptions *)index->rd_options;
+    ldb_HnswOptions *opts = (ldb_HnswOptions *)index->rd_options;
     if(opts) return opts->dims;
     return HNSW_DEFAULT_DIMS;
 }
 
-int HnswGetM(Relation index)
+int ldb_HnswGetM(Relation index)
 {
-    HnswOptions *opts = (HnswOptions *)index->rd_options;
+    ldb_HnswOptions *opts = (ldb_HnswOptions *)index->rd_options;
     if(opts) return opts->m;
     return HNSW_DEFAULT_M;
 }
 
-int HnswGetEfConstruction(Relation index)
+int ldb_HnswGetEfConstruction(Relation index)
 {
-    HnswOptions *opts = (HnswOptions *)index->rd_options;
+    ldb_HnswOptions *opts = (ldb_HnswOptions *)index->rd_options;
     if(opts) return opts->ef_construction;
     return HNSW_DEFAULT_EF_CONSTRUCTION;
 }
 
-int HnswGetEf(Relation index)
+int ldb_HnswGetEf(Relation index)
 {
-    HnswOptions *opts = (HnswOptions *)index->rd_options;
+    ldb_HnswOptions *opts = (ldb_HnswOptions *)index->rd_options;
     if(opts) return opts->ef;
     return HNSW_DEFAULT_EF;
 }
 
-char *HnswGetIndexFilePath(Relation index)
+char *ldb_HnswGetIndexFilePath(Relation index)
 {
-    HnswOptions *opts = (HnswOptions *)index->rd_options;
+    ldb_HnswOptions *opts = (ldb_HnswOptions *)index->rd_options;
     if(!opts) return NULL;
     if(!opts->experimantal_index_path_offset) {
         return NULL;
@@ -74,7 +74,7 @@ char *HnswGetIndexFilePath(Relation index)
     return (char *)opts + opts->experimantal_index_path_offset;
 }
 
-usearch_metric_kind_t HnswGetMetricKind(Relation index)
+usearch_metric_kind_t ldb_HnswGetMetricKind(Relation index)
 {
     struct catclist *proclist = SearchSysCacheList1(AMPROCNUM, ObjectIdGetDatum(index->rd_opfamily[ 0 ]));
 
@@ -114,26 +114,26 @@ static void IndexFileParamValidator(const char *value)
 bytea *ldb_amoptions(Datum reloptions, bool validate)
 {
     static const relopt_parse_elt tab[]
-        = {{"dims", RELOPT_TYPE_INT, offsetof(HnswOptions, dims)},
-           {"element_limit", RELOPT_TYPE_INT, offsetof(HnswOptions, element_limit)},
-           {"m", RELOPT_TYPE_INT, offsetof(HnswOptions, m)},
-           {"ef_construction", RELOPT_TYPE_INT, offsetof(HnswOptions, ef_construction)},
-           {"ef", RELOPT_TYPE_INT, offsetof(HnswOptions, ef)},
-           {"_experimental_index_path", RELOPT_TYPE_STRING, offsetof(HnswOptions, experimantal_index_path_offset)}};
+        = {{"dims", RELOPT_TYPE_INT, offsetof(ldb_HnswOptions, dims)},
+           {"element_limit", RELOPT_TYPE_INT, offsetof(ldb_HnswOptions, element_limit)},
+           {"m", RELOPT_TYPE_INT, offsetof(ldb_HnswOptions, m)},
+           {"ef_construction", RELOPT_TYPE_INT, offsetof(ldb_HnswOptions, ef_construction)},
+           {"ef", RELOPT_TYPE_INT, offsetof(ldb_HnswOptions, ef)},
+           {"_experimental_index_path", RELOPT_TYPE_STRING, offsetof(ldb_HnswOptions, experimantal_index_path_offset)}};
 
 #if PG_VERSION_NUM >= 130000
     LDB_UNUSED(validate);
     return (bytea *)build_reloptions(
-        reloptions, true, ldb_hnsw_index_withopts, sizeof(HnswOptions), tab, lengthof(tab));
+        reloptions, true, ldb_hnsw_index_withopts, sizeof(ldb_HnswOptions), tab, lengthof(tab));
 #else
     // todo::currently unused so out of date
-    relopt_value *options;
-    int           numoptions;
-    HnswOptions  *rdopts;
+    relopt_value    *options;
+    int              numoptions;
+    ldb_HnswOptions *rdopts;
 
     options = parseRelOptions(reloptions, validate, ldb_hnsw_index_withopts, &numoptions);
-    rdopts = allocateReloptStruct(sizeof(HnswOptions), options, numoptions);
-    fillRelOptions((void *)rdopts, sizeof(HnswOptions), options, numoptions, validate, tab, lengthof(tab));
+    rdopts = allocateReloptStruct(sizeof(ldb_HnswOptions), options, numoptions);
+    fillRelOptions((void *)rdopts, sizeof(ldb_HnswOptions), options, numoptions, validate, tab, lengthof(tab));
 
     return (bytea *)rdopts;
 #endif
@@ -230,20 +230,6 @@ void _PG_init(void)
                             NULL,
                             NULL);
 }
-
-// this is only applicable to hnswlib
-// worry about it if/when it is back up to date again
-#if 0
-int
-HnswGetElementLimit(Relation index)
-{
-	HnswOptions *opts = (HnswOptions *) index->rd_options;
-	if (opts)
-		return opts->element_limit;
-		
-	return HNSWLIB_DEFAULT_ELEMENT_LIMIT;
-}
-#endif
 
 // Called with extension unload.
 void _PG_fini(void)

--- a/src/hnsw/options.h
+++ b/src/hnsw/options.h
@@ -29,7 +29,7 @@
 #define LDB_HNSW_DEFAULT_K 10
 #define LDB_HNSW_MAX_K     1000
 /* HNSW index options */
-typedef struct HnswOptions
+typedef struct ldb_HnswOptions
 {
     // max elements the table will ever have. required for hnswlib
     int32 vl_len_; /* varlena header (do not touch directly!) */
@@ -39,15 +39,14 @@ typedef struct HnswOptions
     int   ef_construction;
     int   ef;
     int   experimantal_index_path_offset;
-} HnswOptions;
+} ldb_HnswOptions;
 
-int                   HnswGetDims(Relation index);
-int                   HnswGetM(Relation index);
-int                   HnswGetEfConstruction(Relation index);
-int                   HnswGetEf(Relation index);
-int                   HnswGetElementLimit(Relation index);
-char*                 HnswGetIndexFilePath(Relation index);
-usearch_metric_kind_t HnswGetMetricKind(Relation index);
+int                   ldb_HnswGetDims(Relation index);
+int                   ldb_HnswGetM(Relation index);
+int                   ldb_HnswGetEfConstruction(Relation index);
+int                   ldb_HnswGetEf(Relation index);
+char*                 ldb_HnswGetIndexFilePath(Relation index);
+usearch_metric_kind_t ldb_HnswGetMetricKind(Relation index);
 
 bytea* ldb_amoptions(Datum reloptions, bool validate);
 

--- a/src/hnsw/utils.c
+++ b/src/hnsw/utils.c
@@ -34,10 +34,10 @@ so below the human readable string names can be printed
 
 void PopulateUsearchOpts(Relation index, usearch_init_options_t *opts)
 {
-    opts->connectivity = HnswGetM(index);
-    opts->expansion_add = HnswGetEfConstruction(index);
-    opts->expansion_search = HnswGetEf(index);
-    opts->metric_kind = HnswGetMetricKind(index);
+    opts->connectivity = ldb_HnswGetM(index);
+    opts->expansion_add = ldb_HnswGetEfConstruction(index);
+    opts->expansion_search = ldb_HnswGetEf(index);
+    opts->metric_kind = ldb_HnswGetMetricKind(index);
     opts->metric = NULL;
     opts->quantization = usearch_scalar_f32_k;
 }

--- a/test/expected/hnsw_vector.out
+++ b/test/expected/hnsw_vector.out
@@ -3,9 +3,13 @@
 ---------------------------------------------------------------------
 -- Note: We drop the Lantern extension and re-create it because Lantern only supports
 -- pgvector if it is present on initialization
-DROP EXTENSION lanterndb;
+DROP EXTENSION IF EXISTS lanterndb;
 CREATE EXTENSION vector;
+-- Setting min messages to ERROR so the WARNING about existing hnsw access method is NOT printed
+-- in tests. This makes sure that regression tests pass on pgvector <=0.4.4 as well as >=0.5.0
+SET client_min_messages=ERROR;
 CREATE EXTENSION lanterndb;
+RESET client_min_messages;
 -- Verify basic functionality of pgvector
 SELECT '[1,2,3]'::vector;
  vector  
@@ -16,12 +20,12 @@ SELECT '[1,2,3]'::vector;
 -- Test index creation x2 on empty table and subsequent inserts
 CREATE TABLE items (id SERIAL PRIMARY KEY, trait_ai VECTOR(3));
 INSERT INTO items (trait_ai) VALUES ('[1,2,3]'), ('[4,5,6]');
-CREATE INDEX ON items USING hnsw (trait_ai dist_vec_l2sq_ops) WITH (dims=3, M=2);
+CREATE INDEX ON items USING lantern_hnsw (trait_ai dist_vec_l2sq_ops) WITH (dims=3, M=2);
 INFO:  done init usearch index
 INFO:  inserted 2 elements
 INFO:  done saving 2 vectors
 INSERT INTO items (trait_ai) VALUES ('[6,7,8]');
-CREATE INDEX ON items USING hnsw (trait_ai dist_vec_l2sq_ops) WITH (dims=3, M=4);
+CREATE INDEX ON items USING lantern_hnsw (trait_ai dist_vec_l2sq_ops) WITH (dims=3, M=4);
 INFO:  done init usearch index
 INFO:  inserted 3 elements
 INFO:  done saving 3 vectors
@@ -35,11 +39,11 @@ SELECT * FROM items ORDER BY trait_ai <-> '[0,0,0]' LIMIT 3;
 (3 rows)
 
 SELECT * FROM ldb_get_indexes('items');
-      indexname      | size  |                                           indexdef                                            | total_index_size 
----------------------+-------+-----------------------------------------------------------------------------------------------+------------------
- items_pkey          | 16 kB | CREATE UNIQUE INDEX items_pkey ON public.items USING btree (id)                               | 64 kB
- items_trait_ai_idx  | 24 kB | CREATE INDEX items_trait_ai_idx ON public.items USING hnsw (trait_ai) WITH (dims='3', m='2')  | 64 kB
- items_trait_ai_idx1 | 24 kB | CREATE INDEX items_trait_ai_idx1 ON public.items USING hnsw (trait_ai) WITH (dims='3', m='4') | 64 kB
+      indexname      | size  |                                               indexdef                                                | total_index_size 
+---------------------+-------+-------------------------------------------------------------------------------------------------------+------------------
+ items_pkey          | 16 kB | CREATE UNIQUE INDEX items_pkey ON public.items USING btree (id)                                       | 64 kB
+ items_trait_ai_idx  | 24 kB | CREATE INDEX items_trait_ai_idx ON public.items USING lantern_hnsw (trait_ai) WITH (dims='3', m='2')  | 64 kB
+ items_trait_ai_idx1 | 24 kB | CREATE INDEX items_trait_ai_idx1 ON public.items USING lantern_hnsw (trait_ai) WITH (dims='3', m='4') | 64 kB
 (3 rows)
 
 -- Test index creation on table with existing data
@@ -59,14 +63,14 @@ INSERT INTO small_world (id, b, v) VALUES
     ('110', FALSE, '[1,1,0]'),
     ('111', TRUE,  '[1,1,1]');
 SET enable_seqscan = false;
-CREATE INDEX ON small_world USING hnsw (v) WITH (dims=3, M=5, ef=20, ef_construction=20);
+CREATE INDEX ON small_world USING lantern_hnsw (v) WITH (dims=3, M=5, ef=20, ef_construction=20);
 INFO:  done init usearch index
 INFO:  inserted 8 elements
 INFO:  done saving 8 vectors
 SELECT * FROM ldb_get_indexes('small_world');
-     indexname     | size  |                                                         indexdef                                                          | total_index_size 
--------------------+-------+---------------------------------------------------------------------------------------------------------------------------+------------------
- small_world_v_idx | 24 kB | CREATE INDEX small_world_v_idx ON public.small_world USING hnsw (v) WITH (dims='3', m='5', ef='20', ef_construction='20') | 24 kB
+     indexname     | size  |                                                             indexdef                                                              | total_index_size 
+-------------------+-------+-----------------------------------------------------------------------------------------------------------------------------------+------------------
+ small_world_v_idx | 24 kB | CREATE INDEX small_world_v_idx ON public.small_world USING lantern_hnsw (v) WITH (dims='3', m='5', ef='20', ef_construction='20') | 24 kB
 (1 row)
 
 INSERT INTO small_world (v) VALUES ('[99,99,2]');
@@ -125,7 +129,7 @@ FROM small_world ORDER BY v <-> '[0,1,0]'::VECTOR LIMIT 7;
 -- Verify that index creation on a large vector produces an error
 CREATE TABLE large_vector (v VECTOR(2001));
 \set ON_ERROR_STOP off
-CREATE INDEX ON large_vector USING hnsw (v);
+CREATE INDEX ON large_vector USING lantern_hnsw (v);
 ERROR:  vector dimension 2001 is too large. LanternDB currently supports up to 2000dim vectors
 \set ON_ERROR_STOP on
 -- Validate that index creation works with a larger number of vectors
@@ -135,7 +139,7 @@ CREATE TABLE sift_base10k (
     v VECTOR(128)
 );
 \COPY sift_base10k (v) FROM '/tmp/lanterndb/vector_datasets/siftsmall_base.csv' WITH CSV;
-CREATE INDEX hnsw_idx ON sift_base10k USING hnsw (v);
+CREATE INDEX hnsw_idx ON sift_base10k USING lantern_hnsw (v);
 INFO:  done init usearch index
 INFO:  inserted 10000 elements
 INFO:  done saving 10000 vectors


### PR DESCRIPTION
This PR makes latest LanternDB copatible with pgvector 0.4.4 as well as pgvector 0.5.0
When the newer pgvector is already installed, now we create a compatibility-mode `lantern_hnsw` access method in stead of the `hnsw` default

The PR also renames some of our internal C functions that would otherwise clash with homonymous pgvector functions