### PR TITLE
Fix benchmarking on push event

### DIFF
--- a/.github/workflows/benchmark-linux.yaml
+++ b/.github/workflows/benchmark-linux.yaml
@@ -38,15 +38,16 @@ jobs:
           name: benchmark-results
           path: |
             /tmp/benchmarks-out.json
-      
+
       - name: Find Comment
         uses: peter-evans/find-comment@v2
+        if: ${{ github.event_name == 'pull_request' }}
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
+          comment-author: "github-actions[bot]"
           body-includes: Benchmarks
-      
+
       - name: Comment on PR
         uses: peter-evans/create-or-update-comment@v3
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Currently Benchmark pipeline is running Find Comment step on push events as well which is causing it to [fail](https://github.com/lanterndata/lanterndb/actions/runs/6135134689/job/16648608473) when PRs are merged to main.