### PR TITLE
Fix: Don't run benchmark comment for forks

### DIFF
--- a/.github/workflows/benchmark-linux.yaml
+++ b/.github/workflows/benchmark-linux.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Find Comment
         uses: peter-evans/find-comment@v2
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Comment on PR
         uses: peter-evans/create-or-update-comment@v3
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
See: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks